### PR TITLE
Add Liability Shift to Order Submitted messages

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,8 @@ use Mix.Config
 
 config :apr,
   ecto_repos: [Apr.Repo],
-  gravity_api: Gravity
+  gravity_api: Gravity,
+  payments: Apr.Payments
 
 config :apr, Gravity,
   api_url: System.get_env("GRAVITY_API_URL") || "https://stagingapi.artsy.net",

--- a/config/test.exs
+++ b/config/test.exs
@@ -13,7 +13,8 @@ config :apr, AprWeb.Endpoint,
 config :logger, level: :warn
 
 config :apr,
-  gravity_api: GravityMock
+  gravity_api: GravityMock,
+  payments: Apr.PaymentsMock
 
 # Configure your database
 config :apr, Apr.Repo,

--- a/lib/apr/behaviours/payments_behaviour.ex
+++ b/lib/apr/behaviours/payments_behaviour.ex
@@ -1,0 +1,3 @@
+defmodule Apr.PaymentsBehaviour do
+  @callback liability_shift_happened(string()) :: boolean()
+end

--- a/lib/apr/behaviours/payments_behaviour.ex
+++ b/lib/apr/behaviours/payments_behaviour.ex
@@ -1,3 +1,3 @@
 defmodule Apr.PaymentsBehaviour do
-  @callback liability_shift_happened(string()) :: boolean()
+  @callback liability_shift_happened(String.t()) :: boolean()
 end

--- a/lib/apr/payments.ex
+++ b/lib/apr/payments.ex
@@ -1,0 +1,14 @@
+defmodule Apr.Payments do
+  @behaviour Apr.PaymentsBehaviour
+
+  alias Stripe.PaymentIntent
+
+  def liability_shift_happened(external_charge_id) do
+    with {:ok, pi} <- PaymentIntent.retrieve(external_charge_id, %{expand: ["payment_method"]}),
+         charge <- List.first(pi.charges) do
+      charge.payment_method_details.card.three_d_secure.succeeded
+    else
+      _ -> nil
+    end
+  end
+end

--- a/lib/apr/payments.ex
+++ b/lib/apr/payments.ex
@@ -4,11 +4,13 @@ defmodule Apr.Payments do
   alias Stripe.PaymentIntent
 
   def liability_shift_happened(external_charge_id) do
-    with {:ok, pi} <- PaymentIntent.retrieve(external_charge_id, %{expand: ["payment_method"]}),
-         charge <- List.first(pi.charges) do
-      charge.payment_method_details.card.three_d_secure.succeeded
+    with {:ok, pi} <- PaymentIntent.retrieve(external_charge_id, %{}),
+         [charge | _tail] <- pi.charges.data,
+         %{three_d_secure: three_d_secure} when is_map(three_d_secure) <- charge.payment_method_details.card,
+         %{succeeded: succeeded} <- three_d_secure do
+      succeeded
     else
-      _ -> nil
+      _ -> false
     end
   end
 end

--- a/lib/apr/subscriptions.ex
+++ b/lib/apr/subscriptions.ex
@@ -102,8 +102,6 @@ defmodule Apr.Subscriptions do
   end
 
   def find_or_create_subscriber(params = %{"channel_id" => channel_id}) do
-    response = Repo.get_by(Subscriber, channel_id: channel_id)
-
     with nil <- Repo.get_by(Subscriber, channel_id: channel_id),
          {:ok, new_subscriber} <-
            create_subscriber(

--- a/lib/apr_web/controllers/ping_controller.ex
+++ b/lib/apr_web/controllers/ping_controller.ex
@@ -1,8 +1,6 @@
 defmodule AprWeb.PingController do
   use AprWeb, :controller
 
-  alias Apr.Commands
-
   def ping(conn, _) do
     json(conn, %{ping: "pong"})
   end

--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,8 @@ defmodule Apr.MixProject do
       {:postgrex, ">= 0.0.0"},
       {:sentient, git: "https://github.com/rdalin82/sentient.git"},
       {:slack, "~> 0.15.0"},
-      {:stripity_stripe, "~> 2.4.0"}
+      {:stripity_stripe, "~> 2.4.0"},
+      {:mox, "~> 0.5", only: :test}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -26,6 +26,7 @@
   "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm"},
   "money": {:hex, :money, "1.4.0", "d9e1725832073566dc0c015603b1e82d69f5bd6c51299e9558e61aa6158044da", [:mix], [{:ecto, "~> 1.0 or ~> 2.0 or ~> 2.1 or ~> 3.0", [hex: :ecto, repo: "hexpm", optional: true]}, {:phoenix_html, "~> 2.0", [hex: :phoenix_html, repo: "hexpm", optional: true]}], "hexpm"},
+  "mox": {:hex, :mox, "0.5.1", "f86bb36026aac1e6f924a4b6d024b05e9adbed5c63e8daa069bd66fb3292165b", [:mix], [], "hexpm"},
   "neuron": {:hex, :neuron, "1.1.1", "17608cec9c9cdddad33e671d8c9061790414580c94963122ef209f48ed1ed897", [:mix], [{:httpoison, "~> 1.0", [hex: :httpoison, repo: "hexpm", optional: false]}, {:poison, "~> 3.1", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "oauth2": {:hex, :oauth2, "1.0.1", "2a116de7863d4b5a8a265d77e62b17a6f54e0c01a5bbbf02210783cb861e49ac", [:mix], [{:hackney, "~> 1.13", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},

--- a/test/apr/views/commerce/commerce_order_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_order_slack_view_test.exs
@@ -2,12 +2,19 @@ defmodule Apr.Views.CommerceOrderSlackViewTest do
   use ExUnit.Case, async: true
   alias Apr.Views.CommerceOrderSlackView
   alias Apr.Fixtures
+  import Mox
 
+  setup do
+    expect(Apr.PaymentsMock, :liability_shift_happened, fn _x -> true end)
+    :ok
+  end
   test "submitted buy order" do
     event = Fixtures.commerce_order_event()
     slack_view = CommerceOrderSlackView.render(event, "order.submitted")
     assert slack_view.text == "🤞 Submitted <https://www.artsy.net/artwork/artwork1| >"
     assert slack_view[:unfurl_links] == true
+    [%{fields: fields} | _tail] = slack_view[:attachments]
+    assert Enum.find(fields, fn f -> f[:title] == "Liablity Shift" end)[:value] == true
   end
 
   test "submitted offer order" do

--- a/test/apr/views/commerce_slack_view_test.exs
+++ b/test/apr/views/commerce_slack_view_test.exs
@@ -24,6 +24,7 @@ defmodule Apr.Views.CommerceSlackViewTest do
   end
 
   test "Order event renders order message" do
+    Mox.expect(Apr.PaymentsMock, :liability_shift_happened, fn _x -> true end)
     event = Fixtures.commerce_order_event()
     slack_view = CommerceSlackView.render(event, "order.submitted")
     assert slack_view.text == "🤞 Submitted <https://www.artsy.net/artwork/artwork1| >"

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -1,7 +1,6 @@
 defmodule Apr.Fixtures do
   alias Apr.Subscriptions
   alias Apr.Events
-  @review_default_attrs %{response: true, review_type: "dobar"}
 
   @subscriber_attrs %{
     team_id: "team_id",

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -101,6 +101,7 @@ defmodule Apr.Fixtures do
         "currency_code" => "USD",
         "items_total_cents" => 2_000_000,
         "total_list_price_cents" => 3000,
+        "external_charge_id" => "pi_1",
         "line_items" => [
           %{
             "id" => "li-1",

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,0 +1,1 @@
+Mox.defmock(Apr.PaymentsMock, for: Apr.PaymentsBehaviour)


### PR DESCRIPTION
# Change
https://artsyproduct.atlassian.net/browse/PURCHASE-1378
We want to show in our slack messages if Liability Shift has happened.

- We introduced new `Payments` module which implements newly added `PaymentsBehaviour` by implementing `liability_shift_happened` method that gets a payment intent id and returns boolean.
- In order to properly test, we added `mox` which can be used to add mock for behaviours, in our order slack test we mock `Payments` using `mox` to return true for liability shift and we make sure we get that in the attachments.