### PR TITLE
Follow up on transaction event

### DIFF
--- a/lib/apr/views/commerce/commerce_order_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_order_slack_view.ex
@@ -139,7 +139,7 @@ defmodule Apr.Views.CommerceOrderSlackView do
       },
       %{
         title: "Buyer",
-        value: "<#{exchange_user_orders_link(buyer["id"])}|#{cleanup_name(buyer["name"])}>",
+        value: "<#{exchange_user_orders_link(buyer["_id"])}|#{cleanup_name(buyer["name"])}>",
         short: true
       },
       %{

--- a/lib/apr/views/commerce/commerce_transaction_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_transaction_slack_view.ex
@@ -73,7 +73,7 @@ defmodule Apr.Views.CommerceTransactionSlackView do
           color: "#6E1FFF",
           title: event["properties"]["failure_message"],
           title_link: stripe_search_link(event["properties"]["order"]["id"]),
-          author_name: event["properties"]["failure_code"],
+          author_name: "#{event["properties"]["failure_code"]} / #{event["properties"]["decline_code"]}}",
           author_link: stripe_search_link(event["properties"]["order"]["id"]),
           fields:
             [
@@ -115,7 +115,7 @@ defmodule Apr.Views.CommerceTransactionSlackView do
         %{
           title: "Risk Level",
           value: pi.charge_data.risk_level,
-          short: false
+          short: true
         },
         %{
           title: "Card Country",


### PR DESCRIPTION
based on https://artsy.slack.com/archives/CDKJ10VEH/p1573189088010900, 
- added `decline_code` to the data we show
- moved Risk Level to the right

#mergeOnGreen