### PR TITLE
Add support for `themes` in slack notifications

### DIFF
--- a/lib/apr/commands.ex
+++ b/lib/apr/commands.ex
@@ -77,15 +77,20 @@ defmodule Apr.Commands do
     """
   end
 
+  defp parse_text(subscribe_to_text) do
+    pattern = ~r/(?<topic_name>\w+)(:(?<routing_key>\w+))?(->(?<theme>\w+))?/
+    Regex.named_captures(pattern, subscribe_to_text)
+  end
+
   defp subscribe_to(subscriber, topic_str) do
-    with [topic_name | routing_key] = String.split(topic_str, ":", parts: 2),
+    with %{"topic_name" => topic_name, "routing_key" => routing_key, "theme" => theme} <- parse_text(topic_str),
          topic when not is_nil(topic) <- Subscriptions.get_topic_by_name(topic_name),
-         routing_key <- List.first(routing_key),
          {:ok, subscription} <-
            Subscriptions.create_subscription(%{
              topic_id: topic.id,
              subscriber_id: subscriber.id,
-             routing_key: routing_key || "#"
+             routing_key: routing_key,
+             theme: theme
            }) do
       %{topic: topic_name, subscription: subscription}
     end

--- a/lib/apr/notifications.ex
+++ b/lib/apr/notifications.ex
@@ -56,7 +56,7 @@ defmodule Apr.Notifications do
     end
   end
 
-  defp post_message({subscriber, slack_message}) do
+  defp post_message({subscriber, slack_message}) when not is_nil(slack_message) do
     if slack_message != nil do
       Slack.Web.Chat.post_message(
         "##{subscriber.channel_name}",
@@ -69,4 +69,6 @@ defmodule Apr.Notifications do
       )
     end
   end
+
+  defp post_message(_), do: nil
 end

--- a/lib/apr/notifications.ex
+++ b/lib/apr/notifications.ex
@@ -5,7 +5,7 @@ defmodule Apr.Notifications do
   def receive_event(event, topic, routing_key) do
     get_subscriptions(topic, routing_key)
     |> Enum.map(&{&1, slack_message(&1, event, topic, routing_key)})
-    |> Enum.map(&post_message(&1))
+    |> Enum.map(&post_message/1)
   end
 
   defp get_subscriptions(topic, routing_key) do

--- a/lib/apr/notifications.ex
+++ b/lib/apr/notifications.ex
@@ -3,69 +3,70 @@ defmodule Apr.Notifications do
   require Logger
 
   def receive_event(event, topic, routing_key) do
-    event
-    |> slack_message(topic, routing_key)
-    |> post_message(topic, routing_key)
+    get_subscriptions(topic, routing_key)
+    |> Enum.map(&{&1, slack_message(&1, event, topic, routing_key)})
+    |> Enum.map(&post_message(&1))
   end
 
-  def slack_message(event, topic_name, routing_key) do
+  defp get_subscriptions(topic, routing_key) do
+    Subscriptions.get_topic_subscribers(topic, routing_key)
+  end
+
+  def slack_message(subscription, event, topic_name, routing_key) do
     with topic when not is_nil(topic) <- Subscriptions.get_topic_by_name(topic_name) do
       case topic.name do
         "subscriptions" ->
-          Apr.Views.SubscriptionSlackView.render(event)
+          Apr.Views.SubscriptionSlackView.render(subscription, event)
 
         "inquiries" ->
-          Apr.Views.InquirySlackView.render(event)
+          Apr.Views.InquirySlackView.render(subscription, event)
 
         "purchases" ->
-          Apr.Views.PurchaseSlackView.render(event)
+          Apr.Views.PurchaseSlackView.render(subscription, event)
 
         "auctions" ->
-          Apr.Views.BiddingSlackView.render(event)
+          Apr.Views.BiddingSlackView.render(subscription, event)
 
         "radiation.messages" ->
-          Apr.Views.RadiationMessageSlackView.render(event)
+          Apr.Views.RadiationMessageSlackView.render(subscription, event)
 
         "conversations" ->
-          Apr.Views.ConversationSlackView.render(event)
+          Apr.Views.ConversationSlackView.render(subscription, event)
 
         "invoices" ->
-          Apr.Views.InvoiceSlackView.render(event, routing_key)
+          Apr.Views.InvoiceSlackView.render(subscription, event, routing_key)
 
         "consignments" ->
-          Apr.Views.ConsignmentsSlackView.render(event)
+          Apr.Views.ConsignmentsSlackView.render(subscription, event)
 
         "feedbacks" ->
-          Apr.Views.FeedbacksSlackView.render(event)
+          Apr.Views.FeedbacksSlackView.render(subscription, event)
 
         "sales" ->
-          Apr.Views.SalesSlackView.render(event, routing_key)
+          Apr.Views.SalesSlackView.render(subscription, event, routing_key)
 
         "commerce" ->
-          Apr.Views.CommerceSlackView.render(event, routing_key)
+          Apr.Views.CommerceSlackView.render(subscription, event, routing_key)
 
         "partners" ->
-          Apr.Views.PartnersSlackView.render(event, routing_key)
+          Apr.Views.PartnersSlackView.render(subscription, event, routing_key)
       end
     else
       _ -> Logger.warn("Unknown Topic #{topic_name}")
     end
   end
 
-  defp post_message(slack_message, topic, routing_key) do
+  defp post_message({subscriber, slack_message}) do
     if slack_message != nil do
-      Subscriptions.get_topic_subscribers(topic, routing_key)
-      |> Enum.each(fn subscriber ->
-        Slack.Web.Chat.post_message(
-          "##{subscriber.channel_name}",
-          slack_message[:text],
-          %{
-            attachments: Poison.encode!(slack_message[:attachments]),
-            unfurl_links: slack_message[:unfurl_links],
-            as_user: true
-          }
-        )
-      end)
+      Slack.Web.Chat.post_message(
+        "##{subscriber.channel_name}",
+        slack_message[:text],
+        %{
+          attachments: Poison.encode!(slack_message[:attachments]),
+          unfurl_links: slack_message[:unfurl_links],
+          as_user: true
+        }
+      )
     end
   end
 end

--- a/lib/apr/notifications.ex
+++ b/lib/apr/notifications.ex
@@ -3,13 +3,9 @@ defmodule Apr.Notifications do
   require Logger
 
   def receive_event(event, topic, routing_key) do
-    get_subscriptions(topic, routing_key)
+    Subscriptions.get_topic_subscribers(topic, routing_key)
     |> Enum.map(&{&1, slack_message(&1, event, topic, routing_key)})
     |> Enum.map(&post_message/1)
-  end
-
-  defp get_subscriptions(topic, routing_key) do
-    Subscriptions.get_topic_subscribers(topic, routing_key)
   end
 
   def slack_message(subscription, event, topic_name, routing_key) do

--- a/lib/apr/subscriptions/subscription.ex
+++ b/lib/apr/subscriptions/subscription.ex
@@ -4,6 +4,7 @@ defmodule Apr.Subscriptions.Subscription do
 
   schema "subscriptions" do
     field :routing_key, :string
+    field :theme, :string
 
     belongs_to :topic, Apr.Subscriptions.Topic
     belongs_to :subscriber, Apr.Subscriptions.Subscriber
@@ -12,7 +13,7 @@ defmodule Apr.Subscriptions.Subscription do
   end
 
   @required_fields ~w(topic_id subscriber_id)a
-  @optional_fields ~w(routing_key)a
+  @optional_fields ~w(routing_key theme)a
 
   def changeset(model, attrs) do
     model

--- a/lib/apr/subscriptions/subscription.ex
+++ b/lib/apr/subscriptions/subscription.ex
@@ -3,8 +3,8 @@ defmodule Apr.Subscriptions.Subscription do
   import Ecto.Changeset
 
   schema "subscriptions" do
-    field :routing_key, :string
-    field :theme, :string
+    field :routing_key, :string, default: "#"
+    field :theme, :string, default: nil
 
     belongs_to :topic, Apr.Subscriptions.Topic
     belongs_to :subscriber, Apr.Subscriptions.Subscriber

--- a/lib/apr/views/bidding_slack_view.ex
+++ b/lib/apr/views/bidding_slack_view.ex
@@ -3,7 +3,7 @@ defmodule Apr.Views.BiddingSlackView do
 
   import Apr.Views.Helper
 
-  def render(event) do
+  def render(_subscription, event) do
     artwork_data = fetch_sale_artwork(event["lotId"])
 
     %{

--- a/lib/apr/views/bidding_slack_view.ex
+++ b/lib/apr/views/bidding_slack_view.ex
@@ -3,10 +3,6 @@ defmodule Apr.Views.BiddingSlackView do
 
   import Apr.Views.Helper
 
-  def render(event) do
-    render(nil, event)
-  end
-
   def render(_subscription, event) do
     artwork_data = fetch_sale_artwork(event["lotId"])
 

--- a/lib/apr/views/bidding_slack_view.ex
+++ b/lib/apr/views/bidding_slack_view.ex
@@ -3,6 +3,10 @@ defmodule Apr.Views.BiddingSlackView do
 
   import Apr.Views.Helper
 
+  def render(event) do
+    render(nil, event)
+  end
+
   def render(_subscription, event) do
     artwork_data = fetch_sale_artwork(event["lotId"])
 

--- a/lib/apr/views/commerce_slack_view.ex
+++ b/lib/apr/views/commerce_slack_view.ex
@@ -10,8 +10,12 @@ defmodule Apr.Views.CommerceSlackView do
     Subscription
   }
 
-  def render(event, routing_key) do
+  def render(%Subscription{theme: theme}, event, routing_key) when is_nil(theme) do
     render(nil, event, routing_key)
+  end
+
+  def render(%Subscription{theme: "fraud"}, _event, _routing_key) do
+    nil
   end
 
   def render(nil, event, routing_key) do
@@ -31,14 +35,6 @@ defmodule Apr.Views.CommerceSlackView do
       true ->
         nil
     end
-  end
-
-  def render(%Subscription{theme: theme}, event, routing_key) when is_nil(theme) do
-    render(nil, event, routing_key)
-  end
-
-  def render(%Subscription{theme: "fraud"}, _event, _routing_key) do
-    nil
   end
 
   def render(_, _, _), do: nil

--- a/lib/apr/views/commerce_slack_view.ex
+++ b/lib/apr/views/commerce_slack_view.ex
@@ -10,15 +10,11 @@ defmodule Apr.Views.CommerceSlackView do
     Subscription
   }
 
-  def render(%Subscription{theme: theme}, event, routing_key) when is_nil(theme) do
-    render(nil, event, routing_key)
-  end
-
   def render(%Subscription{theme: "fraud"}, _event, _routing_key) do
     nil
   end
 
-  def render(nil, event, routing_key) do
+  def render(_, event, routing_key) do
     cond do
       routing_key == "transaction.failure" ->
         CommerceTransactionSlackView.render(event, routing_key)
@@ -36,6 +32,4 @@ defmodule Apr.Views.CommerceSlackView do
         nil
     end
   end
-
-  def render(_, _, _), do: nil
 end

--- a/lib/apr/views/commerce_slack_view.ex
+++ b/lib/apr/views/commerce_slack_view.ex
@@ -10,7 +10,11 @@ defmodule Apr.Views.CommerceSlackView do
     Subscription
   }
 
-  def render(%Subscription{theme: theme}, event, routing_key) when is_nil(theme) do
+  def render(event, routing_key) do
+    render(nil, event, routing_key)
+  end
+
+  def render(nil, event, routing_key) do
     cond do
       routing_key == "transaction.failure" ->
         CommerceTransactionSlackView.render(event, routing_key)
@@ -27,6 +31,10 @@ defmodule Apr.Views.CommerceSlackView do
       true ->
         nil
     end
+  end
+
+  def render(%Subscription{theme: theme}, event, routing_key) when is_nil(theme) do
+    render(nil, event, routing_key)
   end
 
   def render(%Subscription{theme: "fraud"}, _event, _routing_key) do

--- a/lib/apr/views/commerce_slack_view.ex
+++ b/lib/apr/views/commerce_slack_view.ex
@@ -6,7 +6,11 @@ defmodule Apr.Views.CommerceSlackView do
     CommerceErrorSlackView
   }
 
-  def render(event, routing_key) do
+  alias Apr.Subscriptions.{
+    Subscription
+  }
+
+  def render(%Subscription{theme: theme}, event, routing_key) when is_nil(theme) do
     cond do
       routing_key == "transaction.failure" ->
         CommerceTransactionSlackView.render(event, routing_key)
@@ -24,4 +28,10 @@ defmodule Apr.Views.CommerceSlackView do
         nil
     end
   end
+
+  def render(%Subscription{theme: "fraud"}, _event, _routing_key) do
+    nil
+  end
+
+  def render(_, _, _), do: nil
 end

--- a/lib/apr/views/consignments_slack_view.ex
+++ b/lib/apr/views/consignments_slack_view.ex
@@ -3,6 +3,10 @@ defmodule Apr.Views.ConsignmentsSlackView do
 
   import Apr.Views.Helper
 
+  def render(event) do
+    render(nil, event)
+  end
+
   def render(_subscription, event) do
     artist_data = fetch_artist(event["properties"]["artist_id"])
 

--- a/lib/apr/views/consignments_slack_view.ex
+++ b/lib/apr/views/consignments_slack_view.ex
@@ -3,7 +3,7 @@ defmodule Apr.Views.ConsignmentsSlackView do
 
   import Apr.Views.Helper
 
-  def render(event) do
+  def render(_subscription, event) do
     artist_data = fetch_artist(event["properties"]["artist_id"])
 
     %{

--- a/lib/apr/views/consignments_slack_view.ex
+++ b/lib/apr/views/consignments_slack_view.ex
@@ -3,10 +3,6 @@ defmodule Apr.Views.ConsignmentsSlackView do
 
   import Apr.Views.Helper
 
-  def render(event) do
-    render(nil, event)
-  end
-
   def render(_subscription, event) do
     artist_data = fetch_artist(event["properties"]["artist_id"])
 

--- a/lib/apr/views/conversation_slack_view.ex
+++ b/lib/apr/views/conversation_slack_view.ex
@@ -1,10 +1,6 @@
 defmodule Apr.Views.ConversationSlackView do
   import Apr.Views.Helper
 
-  def render(event) do
-    render(nil, event)
-  end
-
   def render(_subscription, event) do
     case event["verb"] do
       "buyer_outcome_set" ->
@@ -55,7 +51,12 @@ defmodule Apr.Views.ConversationSlackView do
                 },
                 %{
                   title: "Radiation",
-                  value: "#{radiation_conversation_link(event["properties"]["radiation_conversation_id"])}",
+                  value:
+                    "#{
+                      radiation_conversation_link(
+                        event["properties"]["radiation_conversation_id"]
+                      )
+                    }",
                   short: false
                 }
               ]

--- a/lib/apr/views/conversation_slack_view.ex
+++ b/lib/apr/views/conversation_slack_view.ex
@@ -1,7 +1,7 @@
 defmodule Apr.Views.ConversationSlackView do
   import Apr.Views.Helper
 
-  def render(event) do
+  def render(_subscription, event) do
     case event["verb"] do
       "buyer_outcome_set" ->
         if event["properties"]["buyer_outcome"] == "other" do

--- a/lib/apr/views/conversation_slack_view.ex
+++ b/lib/apr/views/conversation_slack_view.ex
@@ -1,6 +1,10 @@
 defmodule Apr.Views.ConversationSlackView do
   import Apr.Views.Helper
 
+  def render(event) do
+    render(nil, event)
+  end
+
   def render(_subscription, event) do
     case event["verb"] do
       "buyer_outcome_set" ->

--- a/lib/apr/views/feedbacks_slack_view.ex
+++ b/lib/apr/views/feedbacks_slack_view.ex
@@ -17,10 +17,6 @@ defmodule Apr.Views.FeedbacksSlackView do
     String.replace(message, ~r/(\S+)@\S+/m, "\\1[@domain]", global: true)
   end
 
-  def render(event) do
-    render(nil, event)
-  end
-
   def render(_subscription, event) do
     %{
       text:

--- a/lib/apr/views/feedbacks_slack_view.ex
+++ b/lib/apr/views/feedbacks_slack_view.ex
@@ -17,6 +17,10 @@ defmodule Apr.Views.FeedbacksSlackView do
     String.replace(message, ~r/(\S+)@\S+/m, "\\1[@domain]", global: true)
   end
 
+  def render(event) do
+    render(nil, event)
+  end
+
   def render(_subscription, event) do
     %{
       text:

--- a/lib/apr/views/feedbacks_slack_view.ex
+++ b/lib/apr/views/feedbacks_slack_view.ex
@@ -17,7 +17,7 @@ defmodule Apr.Views.FeedbacksSlackView do
     String.replace(message, ~r/(\S+)@\S+/m, "\\1[@domain]", global: true)
   end
 
-  def render(event) do
+  def render(_subscription, event) do
     %{
       text:
         "#{prefix(event)} #{cleanup_name(event["properties"]["user_name"])} #{event["verb"]} from #{

--- a/lib/apr/views/inquiry_slack_view.ex
+++ b/lib/apr/views/inquiry_slack_view.ex
@@ -1,7 +1,7 @@
 defmodule Apr.Views.InquirySlackView do
   import Apr.Views.Helper
 
-  def render(event) do
+  def render(_subscription, event) do
     %{
       text:
         ":shaka: #{cleanup_name(event["subject"]["display"])} #{event["verb"]} on #{

--- a/lib/apr/views/inquiry_slack_view.ex
+++ b/lib/apr/views/inquiry_slack_view.ex
@@ -1,10 +1,6 @@
 defmodule Apr.Views.InquirySlackView do
   import Apr.Views.Helper
 
-  def render(event) do
-    render(nil, event)
-  end
-
   def render(_subscription, event) do
     %{
       text:

--- a/lib/apr/views/inquiry_slack_view.ex
+++ b/lib/apr/views/inquiry_slack_view.ex
@@ -1,6 +1,10 @@
 defmodule Apr.Views.InquirySlackView do
   import Apr.Views.Helper
 
+  def render(event) do
+    render(nil, event)
+  end
+
   def render(_subscription, event) do
     %{
       text:

--- a/lib/apr/views/invoice_slack_view.ex
+++ b/lib/apr/views/invoice_slack_view.ex
@@ -2,10 +2,6 @@ defmodule Apr.Views.InvoiceSlackView do
   @gravity_api Application.get_env(:apr, :gravity_api)
   import Apr.Views.Helper
 
-  def render(event, routing_key) do
-    render(nil, event, routing_key)
-  end
-
   def render(_subscription, event, routing_key) do
     partner_data = fetch_partner_data(event["properties"]["partner_id"])
 

--- a/lib/apr/views/invoice_slack_view.ex
+++ b/lib/apr/views/invoice_slack_view.ex
@@ -2,6 +2,10 @@ defmodule Apr.Views.InvoiceSlackView do
   @gravity_api Application.get_env(:apr, :gravity_api)
   import Apr.Views.Helper
 
+  def render(event, routing_key) do
+    render(nil, event, routing_key)
+  end
+
   def render(_subscription, event, routing_key) do
     partner_data = fetch_partner_data(event["properties"]["partner_id"])
 

--- a/lib/apr/views/invoice_slack_view.ex
+++ b/lib/apr/views/invoice_slack_view.ex
@@ -2,7 +2,7 @@ defmodule Apr.Views.InvoiceSlackView do
   @gravity_api Application.get_env(:apr, :gravity_api)
   import Apr.Views.Helper
 
-  def render(event, routing_key) do
+  def render(_subscription, event, routing_key) do
     partner_data = fetch_partner_data(event["properties"]["partner_id"])
 
     cond do

--- a/lib/apr/views/partners_slack_view.ex
+++ b/lib/apr/views/partners_slack_view.ex
@@ -1,8 +1,4 @@
 defmodule Apr.Views.PartnersSlackView do
-  def render(event, routing_key) do
-    render(nil, event, routing_key)
-  end
-
   def render(_subscription, event = %{"verb" => "updated", "properties" => %{"changes" => changes}}, _) do
     if Enum.member?(changes, "vat_status") do
       %{

--- a/lib/apr/views/partners_slack_view.ex
+++ b/lib/apr/views/partners_slack_view.ex
@@ -1,5 +1,5 @@
 defmodule Apr.Views.PartnersSlackView do
-  def render(event = %{"verb" => "updated", "properties" => %{"changes" => changes}}, _) do
+  def render(_subscription, event = %{"verb" => "updated", "properties" => %{"changes" => changes}}, _) do
     if Enum.member?(changes, "vat_status") do
       %{
         text: ":uk: #{event["properties"]["given_name"]} has set VAT status to #{event["properties"]["vat_status"]}",

--- a/lib/apr/views/partners_slack_view.ex
+++ b/lib/apr/views/partners_slack_view.ex
@@ -1,4 +1,8 @@
 defmodule Apr.Views.PartnersSlackView do
+  def render(event, routing_key) do
+    render(nil, event, routing_key)
+  end
+
   def render(_subscription, event = %{"verb" => "updated", "properties" => %{"changes" => changes}}, _) do
     if Enum.member?(changes, "vat_status") do
       %{
@@ -11,5 +15,5 @@ defmodule Apr.Views.PartnersSlackView do
     end
   end
 
-  def render(_, _), do: nil
+  def render(_, _, _), do: nil
 end

--- a/lib/apr/views/purchase_slack_view.ex
+++ b/lib/apr/views/purchase_slack_view.ex
@@ -1,10 +1,6 @@
 defmodule Apr.Views.PurchaseSlackView do
   import Apr.Views.Helper
 
-  def render(event) do
-    render(nil, event)
-  end
-
   def render(_subscription, event) do
     %{
       text:

--- a/lib/apr/views/purchase_slack_view.ex
+++ b/lib/apr/views/purchase_slack_view.ex
@@ -1,6 +1,10 @@
 defmodule Apr.Views.PurchaseSlackView do
   import Apr.Views.Helper
 
+  def render(event) do
+    render(nil, event)
+  end
+
   def render(_subscription, event) do
     %{
       text:

--- a/lib/apr/views/purchase_slack_view.ex
+++ b/lib/apr/views/purchase_slack_view.ex
@@ -1,7 +1,7 @@
 defmodule Apr.Views.PurchaseSlackView do
   import Apr.Views.Helper
 
-  def render(event) do
+  def render(_subscription, event) do
     %{
       text:
         ":shake: #{cleanup_name(event["subject"]["display"])} #{event["verb"]} #{

--- a/lib/apr/views/radiation_message_slack_view.ex
+++ b/lib/apr/views/radiation_message_slack_view.ex
@@ -1,6 +1,10 @@
 defmodule Apr.Views.RadiationMessageSlackView do
   import Apr.Views.Helper
 
+  def render(event) do
+    render(nil, event)
+  end
+
   def render(_subscription, event) do
     %{
       text: ":sadbot: #{event["verb"]} event for #{radiation_link(event["object"]["link"])}",

--- a/lib/apr/views/radiation_message_slack_view.ex
+++ b/lib/apr/views/radiation_message_slack_view.ex
@@ -1,10 +1,6 @@
 defmodule Apr.Views.RadiationMessageSlackView do
   import Apr.Views.Helper
 
-  def render(event) do
-    render(nil, event)
-  end
-
   def render(_subscription, event) do
     %{
       text: ":sadbot: #{event["verb"]} event for #{radiation_link(event["object"]["link"])}",

--- a/lib/apr/views/radiation_message_slack_view.ex
+++ b/lib/apr/views/radiation_message_slack_view.ex
@@ -1,7 +1,7 @@
 defmodule Apr.Views.RadiationMessageSlackView do
   import Apr.Views.Helper
 
-  def render(event) do
+  def render(_subscription, event) do
     %{
       text: ":sadbot: #{event["verb"]} event for #{radiation_link(event["object"]["link"])}",
       attachments: [

--- a/lib/apr/views/sales_slack_view.ex
+++ b/lib/apr/views/sales_slack_view.ex
@@ -4,7 +4,7 @@ defmodule Apr.Views.SalesSlackView do
 
   import Apr.Views.Helper
 
-  def render(event, routing_key) do
+  def render(_subscription, event, routing_key) do
     sale = fetch_sale(event["properties"]["id"])
 
     case routing_key do

--- a/lib/apr/views/sales_slack_view.ex
+++ b/lib/apr/views/sales_slack_view.ex
@@ -4,6 +4,10 @@ defmodule Apr.Views.SalesSlackView do
 
   import Apr.Views.Helper
 
+  def render(event, routing_key) do
+    render(nil, event, routing_key)
+  end
+
   def render(_subscription, event, routing_key) do
     sale = fetch_sale(event["properties"]["id"])
 

--- a/lib/apr/views/sales_slack_view.ex
+++ b/lib/apr/views/sales_slack_view.ex
@@ -4,10 +4,6 @@ defmodule Apr.Views.SalesSlackView do
 
   import Apr.Views.Helper
 
-  def render(event, routing_key) do
-    render(nil, event, routing_key)
-  end
-
   def render(_subscription, event, routing_key) do
     sale = fetch_sale(event["properties"]["id"])
 

--- a/lib/apr/views/subscription_slack_view.ex
+++ b/lib/apr/views/subscription_slack_view.ex
@@ -1,7 +1,7 @@
 defmodule Apr.Views.SubscriptionSlackView do
   import Apr.Views.Helper
 
-  def render(event) do
+  def render(_subscription, event) do
     %{
       text: "",
       attachments: [

--- a/lib/apr/views/subscription_slack_view.ex
+++ b/lib/apr/views/subscription_slack_view.ex
@@ -1,6 +1,10 @@
 defmodule Apr.Views.SubscriptionSlackView do
   import Apr.Views.Helper
 
+  def render(event) do
+    render(nil, event)
+  end
+
   def render(_subscription, event) do
     %{
       text: "",

--- a/lib/apr/views/subscription_slack_view.ex
+++ b/lib/apr/views/subscription_slack_view.ex
@@ -1,10 +1,6 @@
 defmodule Apr.Views.SubscriptionSlackView do
   import Apr.Views.Helper
 
-  def render(event) do
-    render(nil, event)
-  end
-
   def render(_subscription, event) do
     %{
       text: "",

--- a/priv/repo/migrations/20191127193819_add-subscription-theme.exs
+++ b/priv/repo/migrations/20191127193819_add-subscription-theme.exs
@@ -1,0 +1,9 @@
+defmodule :"Elixir.Apr.Repo.Migrations.Add-subscription-theme" do
+  use Ecto.Migration
+
+  def change do
+    alter table(:subscriptions) do
+      add :theme, :string
+    end
+  end
+end

--- a/test/apr/views/commerce_slack_view_test.exs
+++ b/test/apr/views/commerce_slack_view_test.exs
@@ -29,27 +29,27 @@ defmodule Apr.Views.CommerceSlackViewTest do
         "buyer_type" => "user"
       })
 
-    slack_view = CommerceSlackView.render(event, "transaction.failure")
+    slack_view = CommerceSlackView.render(nil, event, "transaction.failure")
 
     assert slack_view.text == ":alert:"
   end
 
   test "Offer event renders offer message" do
     event = Apr.Fixtures.commerce_offer_event("submitted", %{"amount_cents" => 300})
-    slack_view = CommerceSlackView.render(event, "offer.submitted")
+    slack_view = CommerceSlackView.render(nil, event, "offer.submitted")
     assert slack_view.text == ":parrotsunnies: Counteroffer submitted"
   end
 
   test "Order event renders order message" do
     event = Fixtures.commerce_order_event()
-    slack_view = CommerceSlackView.render(event, "order.submitted")
+    slack_view = CommerceSlackView.render(nil, event, "order.submitted")
     assert slack_view.text == "🤞 Submitted  :verified: <https://www.artsy.net/artwork/artwork1| >"
     assert slack_view[:unfurl_links] == true
   end
 
   test "Error event renders error message" do
     event = Apr.Fixtures.commerce_error_event()
-    slack_view = CommerceSlackView.render(event, "error.validation.insufficient_funds")
+    slack_view = CommerceSlackView.render(nil, event, "error.validation.insufficient_funds")
     assert slack_view.text == ":alert: Failed submitting an order"
   end
 end

--- a/test/apr/views/partners_slack_view_test.exs
+++ b/test/apr/views/partners_slack_view_test.exs
@@ -6,7 +6,7 @@ defmodule Apr.Views.PartnersSlackViewTest do
   describe "partner created" do
     test "we return nil" do
       event = Fixtures.partner_update_event("created")
-      slack_view = PartnersSlackView.render(event, "partnergallery.created")
+      slack_view = PartnersSlackView.render(nil, event, "partnergallery.created")
       assert slack_view == nil
     end
   end
@@ -14,13 +14,13 @@ defmodule Apr.Views.PartnersSlackViewTest do
   describe "partner updated" do
     test "VAT was updated we return proper message" do
       event = Fixtures.partner_update_event("updated", ["vat_status", "name"])
-      slack_view = PartnersSlackView.render(event, "partnergallery.updated")
+      slack_view = PartnersSlackView.render(nil, event, "partnergallery.updated")
       assert slack_view.text == ":uk: Invoicing Demo Partner has set VAT status to registered"
     end
 
     test "VAT was not updated we return nil" do
       event = Fixtures.partner_update_event("updated", ["updated_at"])
-      slack_view = PartnersSlackView.render(event, "partnergallery.updated")
+      slack_view = PartnersSlackView.render(nil, event, "partnergallery.updated")
       assert slack_view == nil
     end
   end


### PR DESCRIPTION
In slack we may want to subscribe to multiple events potentially on different topics with custom views or filtering. An example would be subscribing generically to `fraud` and it automatically would hook up all the relevant views/filters/etc. 

Currently the name for this concept is a `theme` but I'm still a little uncertain about it, heh.

This `theme` is added to the subscription object and can be used to adjust the display of certain subscriptions. 