### PR TITLE
Ensure routing_key can have a dot in its name

### DIFF
--- a/lib/apr/commands.ex
+++ b/lib/apr/commands.ex
@@ -78,7 +78,7 @@ defmodule Apr.Commands do
   end
 
   defp parse_text(subscribe_to_text) do
-    pattern = ~r/(?<topic_name>\w+)(:(?<routing_key>\w+))?(->(?<theme>\w+))?/
+    pattern = ~r/(?<topic_name>\w+)(:(?<routing_key>[\w\.]+))?(->(?<theme>\w+))?/
     Regex.named_captures(pattern, subscribe_to_text)
   end
 


### PR DESCRIPTION
`commerce:order.created` wasn't matching properly because we were only using a word match for the route key. I've updated it to be a word or dot match. 

old
```elixir
- Regex.named_captures(~r/(?<topic_name>\w+)(:(?<routing_key>\w+))?(->(?<theme>\w+))?/, "commerce:order.created")
```
new
```elixir
Regex.named_captures(~r/(?<topic_name>\w+)(:(?<routing_key>[\w\.]+))?(->(?<theme>\w+))?/, "commerce:order.created")
```

Try these out in `iex` to see the difference.  