### PR TITLE
Ignore phoenix file imports

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,6 @@
 {
-  "extends": [
-    "@artsy:app"
-  ],
-  "reviewers": [
-    "zephraph"
-  ],
-  "assignees": [
-    "ashkan18"
-  ]
+  "extends": ["@artsy:app"],
+  "reviewers": ["zephraph"],
+  "assignees": ["ashkan18"],
+  "ignoreDeps": ["phoenix", "phoenix_html", "phoenix_live_view"]
 }


### PR DESCRIPTION
Renovate has been failing when it encounters phoenix, phoenix_html, and phoenix_live_view. This _may_ fix the problem. It may also just not be fixable without removing those from the package.json. I'm not certain. 