### PR TITLE
Add fraud theme definition

### DIFF
--- a/lib/apr/views/commerce/commerce_error_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_error_slack_view.ex
@@ -3,7 +3,7 @@
 defmodule Apr.Views.CommerceErrorSlackView do
   import Apr.Views.Helper
 
-  def render(event, _routing_key) do
+  def render(_, event, _routing_key) do
     %{
       text: ":alert: Failed submitting an order",
       attachments: [

--- a/lib/apr/views/commerce/commerce_offer_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_offer_slack_view.ex
@@ -3,7 +3,7 @@ defmodule Apr.Views.CommerceOfferSlackView do
 
   alias Apr.Views.CommerceHelper
 
-  def render(event, routing_key) do
+  def render(_, event, routing_key) do
     case routing_key do
       "offer.submitted" -> offer_submitted(event)
       "offer.pending_response" -> offer_pending_response(event)

--- a/lib/apr/views/commerce/commerce_order_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_order_slack_view.ex
@@ -6,7 +6,19 @@ defmodule Apr.Views.CommerceOrderSlackView do
 
   alias Apr.Views.CommerceHelper
 
-  def render(event, routing_key) do
+  alias Apr.Subscriptions.{
+    Subscription
+  }
+
+  def render(
+        %Subscription{theme: "fraud"},
+        %{"verb" => verb, "properties" => %{"items_total_cents" => items_total_cents}},
+        _routing_key
+      )
+      when items_total_cents < 300_000 or verb != "submitted",
+      do: nil
+
+  def render(_, event, routing_key) do
     event
     |> get_title()
     |> build_message(event, routing_key)

--- a/lib/apr/views/commerce/commerce_order_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_order_slack_view.ex
@@ -15,7 +15,7 @@ defmodule Apr.Views.CommerceOrderSlackView do
         %{"verb" => verb, "properties" => %{"items_total_cents" => items_total_cents}},
         _routing_key
       )
-      when items_total_cents < 300_000 or verb != "submitted",
+      when items_total_cents < 3_000_00 or verb != "submitted",
       do: nil
 
   def render(_, event, routing_key) do

--- a/lib/apr/views/commerce/commerce_transaction_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_transaction_slack_view.ex
@@ -13,7 +13,7 @@ defmodule Apr.Views.CommerceTransactionSlackView do
         %{"properties" => %{"order" => %{"items_total_cents" => items_total_cents}}},
         _routing_key
       )
-      when items_total_cents < 3000_00,
+      when items_total_cents < 300_000,
       do: nil
 
   def render(_, event, _routing_key) do

--- a/lib/apr/views/commerce/commerce_transaction_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_transaction_slack_view.ex
@@ -2,9 +2,21 @@ defmodule Apr.Views.CommerceTransactionSlackView do
   import Apr.Views.Helper
   alias Apr.Views.CommerceHelper
 
+  alias Apr.Subscriptions.{
+    Subscription
+  }
+
   @payments Application.get_env(:apr, :payments)
 
-  def render(event, _routing_key) do
+  def render(
+        %Subscription{theme: "fraud"},
+        %{"properties" => %{"order" => %{"items_total_cents" => items_total_cents}}},
+        _routing_key
+      )
+      when items_total_cents < 3000_00,
+      do: nil
+
+  def render(_, event, _routing_key) do
     order = event["properties"]["order"]
     seller = CommerceHelper.fetch_participant_info(order["seller_id"], order["seller_type"])
     buyer = CommerceHelper.fetch_participant_info(order["buyer_id"], order["buyer_type"])

--- a/lib/apr/views/commerce/commerce_transaction_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_transaction_slack_view.ex
@@ -13,7 +13,7 @@ defmodule Apr.Views.CommerceTransactionSlackView do
         %{"properties" => %{"order" => %{"items_total_cents" => items_total_cents}}},
         _routing_key
       )
-      when items_total_cents < 300_000,
+      when items_total_cents < 3_000_00,
       do: nil
 
   def render(_, event, _routing_key) do

--- a/lib/apr/views/commerce_slack_view.ex
+++ b/lib/apr/views/commerce_slack_view.ex
@@ -6,27 +6,19 @@ defmodule Apr.Views.CommerceSlackView do
     CommerceErrorSlackView
   }
 
-  alias Apr.Subscriptions.{
-    Subscription
-  }
-
-  def render(%Subscription{theme: "fraud"}, _event, _routing_key) do
-    nil
-  end
-
-  def render(_, event, routing_key) do
+  def render(subscription, event, routing_key) do
     cond do
       routing_key == "transaction.failure" ->
-        CommerceTransactionSlackView.render(event, routing_key)
+        CommerceTransactionSlackView.render(subscription, event, routing_key)
 
       routing_key =~ "offer." ->
-        CommerceOfferSlackView.render(event, routing_key)
+        CommerceOfferSlackView.render(subscription, event, routing_key)
 
       routing_key =~ "order." ->
-        CommerceOrderSlackView.render(event, routing_key)
+        CommerceOrderSlackView.render(subscription, event, routing_key)
 
       routing_key =~ "error." ->
-        CommerceErrorSlackView.render(event, routing_key)
+        CommerceErrorSlackView.render(subscription, event, routing_key)
 
       true ->
         nil

--- a/test/apr/views/commerce/commerce_error_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_error_slack_view_test.exs
@@ -1,10 +1,11 @@
 defmodule Apr.Views.CommerceErrorSlackViewTest do
   use ExUnit.Case, async: true
   alias Apr.Views.CommerceErrorSlackView
+  alias Apr.Subscriptions.Subscription
 
   test "commerce error slack view" do
     event = Apr.Fixtures.commerce_error_event()
-    slack_view = CommerceErrorSlackView.render(event, "test_routing_key")
+    slack_view = CommerceErrorSlackView.render(%Subscription{}, event, "test_routing_key")
     assert slack_view.text == ":alert: Failed submitting an order"
 
     assert Enum.map(List.first(slack_view.attachments).fields, fn field -> field.title end) == [

--- a/test/apr/views/commerce/commerce_order_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_order_slack_view_test.exs
@@ -87,7 +87,7 @@ defmodule Apr.Views.CommerceOrderSlackViewTest do
     assert is_nil(slack_view)
   end
 
-  test "returns message for subscription with fraud theme and total cents below threshodl" do
+  test "returns message for subscription with fraud theme and total cents below threshold" do
     event = Fixtures.commerce_order_event("submitted", %{"items_total_cents" => 3000_00})
 
     slack_view = CommerceOrderSlackView.render(@fraud_theme_subscription, event, "order.submitted")

--- a/test/apr/views/commerce/commerce_order_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_order_slack_view_test.exs
@@ -2,7 +2,11 @@ defmodule Apr.Views.CommerceOrderSlackViewTest do
   use ExUnit.Case, async: true
   alias Apr.Views.CommerceOrderSlackView
   alias Apr.Fixtures
+  alias Apr.Subscriptions.Subscription
   import Mox
+
+  @subscription %Subscription{}
+  @fraud_theme_subscription %Subscription{theme: "fraud"}
 
   setup do
     expect(Apr.PaymentsMock, :payment_info, fn _, _ ->
@@ -14,35 +18,35 @@ defmodule Apr.Views.CommerceOrderSlackViewTest do
 
   test "submitted buy order" do
     event = Fixtures.commerce_order_event()
-    slack_view = CommerceOrderSlackView.render(event, "order.submitted")
+    slack_view = CommerceOrderSlackView.render(@subscription, event, "order.submitted")
     assert slack_view.text == "🤞 Submitted  :verified: <https://www.artsy.net/artwork/artwork1| >"
     assert slack_view[:unfurl_links] == true
   end
 
   test "submitted offer order" do
     event = Fixtures.commerce_offer_order()
-    slack_view = CommerceOrderSlackView.render(event, "order.submitted")
+    slack_view = CommerceOrderSlackView.render(@subscription, event, "order.submitted")
     assert slack_view.text == "🤞 Offer Submitted <https://www.artsy.net/artwork/artwork1| >"
     assert slack_view[:unfurl_links] == true
   end
 
   test "approved order" do
     event = Fixtures.commerce_order_event("approved")
-    slack_view = CommerceOrderSlackView.render(event, "order.approved")
+    slack_view = CommerceOrderSlackView.render(@subscription, event, "order.approved")
     assert slack_view.text == ":yes: Approved <https://www.artsy.net/artwork/artwork1| >"
     assert slack_view[:unfurl_links] == true
   end
 
   test "refunded order" do
     event = Fixtures.commerce_order_event("refunded")
-    slack_view = CommerceOrderSlackView.render(event, "order.refunded")
+    slack_view = CommerceOrderSlackView.render(@subscription, event, "order.refunded")
     assert slack_view.text == ":sad-parrot: Refunded <https://www.artsy.net/artwork/artwork1| >"
     assert slack_view[:unfurl_links] == true
   end
 
   test "fulfilled order" do
     event = Fixtures.commerce_order_event("fulfilled")
-    slack_view = CommerceOrderSlackView.render(event, "order.fulfilled")
+    slack_view = CommerceOrderSlackView.render(@subscription, event, "order.fulfilled")
 
     assert slack_view.text ==
              ":shipitmoveit: Fulfilled <https://www.artsy.net/artwork/artwork1| >"
@@ -52,7 +56,7 @@ defmodule Apr.Views.CommerceOrderSlackViewTest do
 
   test "pending_approval order" do
     event = Fixtures.commerce_order_event("pending_approval")
-    slack_view = CommerceOrderSlackView.render(event, "order.pending_approval")
+    slack_view = CommerceOrderSlackView.render(@subscription, event, "order.pending_approval")
 
     assert slack_view.text ==
              ":hourglass: Waiting Approval <https://www.artsy.net/artwork/artwork1| >"
@@ -62,11 +66,31 @@ defmodule Apr.Views.CommerceOrderSlackViewTest do
 
   test "pending_fulfillment order" do
     event = Fixtures.commerce_order_event("pending_fulfillment")
-    slack_view = CommerceOrderSlackView.render(event, "order.pending_fulfillment")
+    slack_view = CommerceOrderSlackView.render(@subscription, event, "order.pending_fulfillment")
 
     assert slack_view.text ==
              ":hourglass: Waiting Shipping <https://www.artsy.net/artwork/artwork1| >"
 
     assert slack_view[:unfurl_links] == true
+  end
+
+  test "returns nil for subscription with fraud theme and events other than submit" do
+    event = Fixtures.commerce_order_event("created")
+    slack_view = CommerceOrderSlackView.render(@fraud_theme_subscription, event, "order.created")
+    assert is_nil(slack_view)
+  end
+
+  test "returns nil for subscription with fraud theme and submitted orders below threshold" do
+    event = Fixtures.commerce_order_event("submitted", %{"items_total_cents" => 2999_00})
+
+    slack_view = CommerceOrderSlackView.render(@fraud_theme_subscription, event, "order.submitted")
+    assert is_nil(slack_view)
+  end
+
+  test "returns message for subscription with fraud theme and total cents below threshodl" do
+    event = Fixtures.commerce_order_event("submitted", %{"items_total_cents" => 3000_00})
+
+    slack_view = CommerceOrderSlackView.render(@fraud_theme_subscription, event, "order.submitted")
+    refute is_nil(slack_view.text)
   end
 end

--- a/test/apr/views/commerce/commerce_transaction_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_transaction_slack_view_test.exs
@@ -93,7 +93,7 @@ defmodule Apr.Views.CommerceTransactionSlackViewTest do
     assert "Shipping Name" not in titles
   end
 
-  test "returns nil for subscription with fraud template and total cents below threshodl" do
+  test "returns nil for subscription with fraud template and total cents below threshold" do
     event =
       Apr.Fixtures.commerce_transaction_event(%{
         "id" => "order123",
@@ -109,7 +109,7 @@ defmodule Apr.Views.CommerceTransactionSlackViewTest do
     assert is_nil(slack_view)
   end
 
-  test "returns message for subscription with fraud template and total cents below threshodl" do
+  test "returns message for subscription with fraud template and total cents below threshold" do
     event =
       Apr.Fixtures.commerce_transaction_event(%{
         "id" => "order123",

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -76,10 +76,10 @@ defmodule Apr.Fixtures do
     }
   end
 
-  def commerce_offer_order(verb \\ "submitted", state_reason \\ nil),
-    do: commerce_order_event(verb, state_reason, "offer")
+  def commerce_offer_order(verb \\ "submitted", properties \\ %{}),
+    do: commerce_order_event(verb, properties |> Map.merge(%{"mode" => "offer"}))
 
-  def commerce_order_event(verb \\ "submitted", state_reason \\ nil, mode \\ "buy") do
+  def commerce_order_event(verb \\ "submitted", properties \\ %{}) do
     %{
       "object" => %{
         "id" => "order123",
@@ -90,24 +90,26 @@ defmodule Apr.Fixtures do
         "display" => "User LastName"
       },
       "verb" => verb,
-      "properties" => %{
-        "mode" => mode,
-        "state_reason" => state_reason,
-        "seller_id" => "partner1",
-        "seller_type" => "gallery",
-        "buyer_id" => "user1",
-        "buyer_type" => "user",
-        "currency_code" => "USD",
-        "items_total_cents" => 2_000_000,
-        "total_list_price_cents" => 3000,
-        "external_charge_id" => "pi_1",
-        "line_items" => [
-          %{
-            "id" => "li-1",
-            "artwork_id" => "artwork1"
-          }
-        ]
-      }
+      "properties" =>
+        %{
+          "mode" => "buy",
+          "state_reason" => nil,
+          "seller_id" => "partner1",
+          "seller_type" => "gallery",
+          "buyer_id" => "user1",
+          "buyer_type" => "user",
+          "currency_code" => "USD",
+          "items_total_cents" => 20000_00,
+          "total_list_price_cents" => 3000,
+          "external_charge_id" => "pi_1",
+          "line_items" => [
+            %{
+              "id" => "li-1",
+              "artwork_id" => "artwork1"
+            }
+          ]
+        }
+        |> Map.merge(properties)
     }
   end
 


### PR DESCRIPTION
# Problem
https://artsyproduct.atlassian.net/browse/PURCHASE-1655

# Solution
Oh my... this was lot easier than what i thought! Basically we now pass `Subscription` to render methods, and in there using fabulous _pattern matching_ we filter out events that are not eligible for `fraud` themed subscription. 

# Selfie
I ❤️ Elixir! 