### PR TITLE
Fix sending subscriber instead of subscription to render

### DIFF
--- a/lib/apr/subscriptions.ex
+++ b/lib/apr/subscriptions.ex
@@ -89,16 +89,15 @@ defmodule Apr.Subscriptions do
   """
   def get_subscriber!(id), do: Repo.get!(Subscriber, id)
 
-  def get_topic_subscribers(topic_name, routing_key) do
-    Repo.all(
-      from s in Subscriber,
-        join: sc in Subscription,
-        on: s.id == sc.subscriber_id,
-        join: t in Topic,
-        on: t.id == sc.topic_id,
-        where: t.name == ^topic_name,
-        where: sc.routing_key == ^routing_key or is_nil(sc.routing_key) or sc.routing_key == "#"
+  def get_subscriptions(topic_name, routing_key) do
+    from(s in Subscription,
+      join: t in Topic,
+      on: t.id == s.topic_id,
+      where: t.name == ^topic_name,
+      where: s.routing_key == ^routing_key or is_nil(s.routing_key) or s.routing_key == "#"
     )
+    |> Repo.all()
+    |> Repo.preload(:subscriber)
   end
 
   def find_or_create_subscriber(params = %{"channel_id" => channel_id}) do

--- a/lib/apr/views/commerce/commerce_order_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_order_slack_view.ex
@@ -6,9 +6,7 @@ defmodule Apr.Views.CommerceOrderSlackView do
 
   alias Apr.Views.CommerceHelper
 
-  alias Apr.Subscriptions.{
-    Subscription
-  }
+  alias Apr.Subscriptions.Subscription
 
   def render(
         %Subscription{theme: "fraud"},
@@ -18,7 +16,7 @@ defmodule Apr.Views.CommerceOrderSlackView do
       when items_total_cents < 3_000_00 or verb != "submitted",
       do: nil
 
-  def render(_, event, routing_key) do
+  def render(_subscription, event, routing_key) do
     event
     |> get_title()
     |> build_message(event, routing_key)


### PR DESCRIPTION
# Problem
After our recent changes, our `render` methods now expect to get a `Subscription` but our logic was sending `Subscriber`. Because of that changes in #62  that were pattern matching based on subscription would never match the fraud case and always go with old render.

# Solution
Fix the call to get subscriptions for specific topic instead of subscribers, we only need subscriber when we want to post message to slack.

# Fun Thing
Used `@spec` to add type around method and make it more obvious what our method expects and what it returns.