### PR TITLE
Not show offer events for Fraud theme

### DIFF
--- a/lib/apr/views/commerce/commerce_offer_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_offer_slack_view.ex
@@ -2,6 +2,9 @@ defmodule Apr.Views.CommerceOfferSlackView do
   import Apr.Views.Helper
 
   alias Apr.Views.CommerceHelper
+  alias Apr.Subscriptions.Subscription
+
+  def render(%Subscription{theme: "fraud"}, _, _), do: nil
 
   def render(_, event, routing_key) do
     case routing_key do

--- a/lib/apr/views/commerce/commerce_order_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_order_slack_view.ex
@@ -10,10 +10,10 @@ defmodule Apr.Views.CommerceOrderSlackView do
 
   def render(
         %Subscription{theme: "fraud"},
-        %{"verb" => verb, "properties" => %{"items_total_cents" => items_total_cents}},
+        %{"verb" => verb, "properties" => %{"items_total_cents" => items_total_cents, "mode" => mode}},
         _routing_key
       )
-      when items_total_cents < 3_000_00 or verb != "submitted",
+      when items_total_cents < 3_000_00 or verb != "submitted" or mode == "offer",
       do: nil
 
   def render(_subscription, event, routing_key) do

--- a/test/apr/views/commerce_slack_view_test.exs
+++ b/test/apr/views/commerce_slack_view_test.exs
@@ -1,6 +1,7 @@
 defmodule Apr.Views.CommerceSlackViewTest do
   use ExUnit.Case, async: true
   alias Apr.Views.CommerceSlackView
+  alias Apr.Subscriptions.Subscription
   alias Apr.Fixtures
   import Mox
 
@@ -38,6 +39,12 @@ defmodule Apr.Views.CommerceSlackViewTest do
     event = Apr.Fixtures.commerce_offer_event("submitted", %{"amount_cents" => 300})
     slack_view = CommerceSlackView.render(nil, event, "offer.submitted")
     assert slack_view.text == ":parrotsunnies: Counteroffer submitted"
+  end
+
+  test "Ignores offer events for fraud theme" do
+    event = Apr.Fixtures.commerce_offer_event("submitted", %{"amount_cents" => 300})
+    slack_view = CommerceSlackView.render(%Subscription{theme: "fraud"}, event, "offer.submitted")
+    assert is_nil(slack_view)
   end
 
   test "Order event renders order message" do


### PR DESCRIPTION
# Problem
We see offers waiting response and submitted events in slack and we don't want it.

https://artsy.slack.com/archives/CRFU26WFM/p1576684782002600

# Solution
filter them out for `fraud` them.