### PR TITLE
Update fraud template to always show failed transactions

### DIFF
--- a/lib/apr/views/commerce/commerce_transaction_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_transaction_slack_view.ex
@@ -2,19 +2,7 @@ defmodule Apr.Views.CommerceTransactionSlackView do
   import Apr.Views.Helper
   alias Apr.Views.CommerceHelper
 
-  alias Apr.Subscriptions.{
-    Subscription
-  }
-
   @payments Application.get_env(:apr, :payments)
-
-  def render(
-        %Subscription{theme: "fraud"},
-        %{"properties" => %{"order" => %{"items_total_cents" => items_total_cents}}},
-        _routing_key
-      )
-      when items_total_cents < 3_000_00,
-      do: nil
 
   def render(_, event, _routing_key) do
     order = event["properties"]["order"]

--- a/test/apr/views/commerce/commerce_transaction_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_transaction_slack_view_test.exs
@@ -93,27 +93,11 @@ defmodule Apr.Views.CommerceTransactionSlackViewTest do
     assert "Shipping Name" not in titles
   end
 
-  test "returns nil for subscription with fraud template and total cents below threshold" do
-    event =
-      Apr.Fixtures.commerce_transaction_event(%{
-        "id" => "order123",
-        "items_total_cents" => 2000_00,
-        "currency_code" => "USD",
-        "seller_id" => "partner1",
-        "seller_type" => "gallery",
-        "buyer_id" => "user1",
-        "buyer_type" => "user"
-      })
-
-    slack_view = CommerceTransactionSlackView.render(@fraud_theme_subscription, event, "transaction.failed")
-    assert is_nil(slack_view)
-  end
-
   test "returns message for subscription with fraud template and total cents below threshold" do
     event =
       Apr.Fixtures.commerce_transaction_event(%{
         "id" => "order123",
-        "items_total_cents" => 3001_00,
+        "items_total_cents" => 2001_00,
         "currency_code" => "USD",
         "seller_id" => "partner1",
         "seller_type" => "gallery",


### PR DESCRIPTION
Wraps up [PURCHASE-1655](https://artsyproduct.atlassian.net/browse/PURCHASE-1655) by ensuring failed transactions always show up under the fraud template. 