### PR TITLE
Not show commerce errors in fraud theme

### DIFF
--- a/lib/apr/views/commerce/commerce_error_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_error_slack_view.ex
@@ -2,6 +2,7 @@
 
 defmodule Apr.Views.CommerceErrorSlackView do
   import Apr.Views.Helper
+  alias Apr.Subscriptions.Subscription
 
   def render(%Subscription{theme: "fraud"}, _, _), do: nil
 

--- a/lib/apr/views/commerce/commerce_error_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_error_slack_view.ex
@@ -3,6 +3,8 @@
 defmodule Apr.Views.CommerceErrorSlackView do
   import Apr.Views.Helper
 
+  def render(%Subscription{theme: "fraud"}, _, _), do: nil
+
   def render(_, event, _routing_key) do
     %{
       text: ":alert: Failed submitting an order",


### PR DESCRIPTION
# Request
CRT does not want to see errors in the `fraud` theme.

# Change
in Error view, ignore rendering for fraud messages.

cc: @zephraph 