### PR TITLE
Add phoenix from npm to resolve renovate failures

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -7,9 +7,9 @@
   },
   "dependencies": {
     "@artsy/palette": "4.17.8",
-    "phoenix": "file:../deps/phoenix",
-    "phoenix_html": "file:../deps/phoenix_html",
-    "phoenix_live_view": "file:../deps/phoenix_live_view",
+    "phoenix": "1.4.10",
+    "phoenix_html": "2.13.2",
+    "phoenix_live_view": "0.3.1",
     "svelte": "3.0.0"
   },
   "devDependencies": {

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -5157,14 +5157,20 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-"phoenix@file:../deps/phoenix":
+phoenix@1.4.10:
   version "1.4.10"
+  resolved "https://registry.yarnpkg.com/phoenix/-/phoenix-1.4.10.tgz#02ebd5bf57bdbeb3ff43d8de6d44a8af7968991b"
+  integrity sha512-apWRDNUj3c//fwh7F7ixh90qejE2j9FFw+e0qSDzYKzszByGrrv9uSmsqol/7x2E+r0GbkXKaeH93eXTQbhJ1A==
 
-"phoenix_html@file:../deps/phoenix_html":
+phoenix_html@2.13.2:
   version "2.13.2"
+  resolved "https://registry.yarnpkg.com/phoenix_html/-/phoenix_html-2.13.2.tgz#28a2376b713e9d8dda0aee8710f7c73732ff0157"
+  integrity sha512-tXrTduDqIisIn0nhZJURLqjaN5aq0nYAwh6wKGQKug6FHEsRmjxWMCVSrPyXo+2ldf7EQLUWdX1ZzlNtyXTsSQ==
 
-"phoenix_live_view@file:../deps/phoenix_live_view":
+phoenix_live_view@0.3.1:
   version "0.3.1"
+  resolved "https://registry.yarnpkg.com/phoenix_live_view/-/phoenix_live_view-0.3.1.tgz#c97187f10587a6b52c34b1d4049ddcc40b5af2b3"
+  integrity sha512-xhFz1eCjYKuhPWsytfS+CtIe+2xmBhhcg59MSPx7LKLX8XwD91wRV8JkorgxT8GW6Mvb26E0xaGLWnAbRrkMPg==
 
 pify@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
cc @ashkan18, @bhoggard 

Renovate updates are failing due to the phoenix dependencies being specified as paths and renovate not being able to find them. I've updated the dependencies to  be the same versions but pulled directly from npm. 