### PR TITLE
Fix failures caused by Postgres

### DIFF
--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -25,5 +25,6 @@ services:
     image: postgres:9.6-alpine
     environment:
     - POSTGRES_DB=postgres
+    - POSTGRES_HOST_AUTH_METHOD=trust
   aprd-rabbitmq:
     image: rabbitmq:3.6-management-alpine


### PR DESCRIPTION
# Problem
Master builds are failing starting from #80 , this means:
- Nothing gets deployed even when getting merged to `master`
- We can't do deploys if needed

Knowing APRd is now one of critical applications at Artsy we shouldn't be in this fail mode for long.

# Solution
Fix postgres issue on Circle.


# Also
Hi 👋 