### PR TITLE
#migration drop nginx ELB servcice and Nginx sidecar containers

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -29,37 +29,6 @@ spec:
         ports:
         - name: aprd-http
           containerPort: 8080
-      - name: aprd-nginx
-        image: artsy/docker-nginx:1.14.2
-        ports:
-          - name: nginx-http
-            containerPort: 80
-          - name: nginx-https
-            containerPort: 8443
-        readinessProbe:
-          tcpSocket:
-            port: nginx-http
-          initialDelaySeconds: 5
-          periodSeconds: 15
-          timeoutSeconds: 10
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/usr/sbin/nginx", "-s", "quit"]
-        env:
-          - name: 'NGINX_DEFAULT_CONF'
-            valueFrom:
-              configMapKeyRef:
-                name: nginx-config
-                key: default-websockets
-        volumeMounts:
-          - name: nginx-secrets
-            mountPath: /etc/nginx/ssl
-      volumes:
-        - name: nginx-secrets
-          secret:
-            secretName: nginx-secrets
-            defaultMode: 420
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:
@@ -84,39 +53,6 @@ spec:
                 operator: In
                 values:
                 - foreground
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: aprd
-    layer: application
-    component: web
-  name: aprd-web
-  namespace: default
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ artsyNetWildcardSSLCert }}
-    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
-spec:
-  ports:
-  - port: 80
-    protocol: TCP
-    name: http
-    targetPort: nginx-http
-  - port: 443
-    protocol: TCP
-    name: https
-    targetPort: nginx-https
-  selector:
-    app: aprd
-    layer: application
-    component: web
-  sessionAffinity: None
-  type: LoadBalancer
 
 ---
 apiVersion: v1

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -29,37 +29,6 @@ spec:
         ports:
         - name: aprd-http
           containerPort: 8080
-      - name: aprd-nginx
-        image: artsy/docker-nginx:1.14.2
-        ports:
-          - name: nginx-http
-            containerPort: 80
-          - name: nginx-https
-            containerPort: 8443
-        readinessProbe:
-          tcpSocket:
-            port: nginx-http
-          initialDelaySeconds: 5
-          periodSeconds: 15
-          timeoutSeconds: 10
-        lifecycle:
-          preStop:
-            exec:
-              command: ["/usr/sbin/nginx", "-s", "quit"]
-        env:
-          - name: 'NGINX_DEFAULT_CONF'
-            valueFrom:
-              configMapKeyRef:
-                name: nginx-config
-                key: default-websockets
-        volumeMounts:
-          - name: nginx-secrets
-            mountPath: /etc/nginx/ssl
-      volumes:
-        - name: nginx-secrets
-          secret:
-            secretName: nginx-secrets
-            defaultMode: 420
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:
@@ -84,39 +53,6 @@ spec:
                 operator: In
                 values:
                 - foreground
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: aprd
-    layer: application
-    component: web
-  name: aprd-web
-  namespace: default
-  annotations:
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ artsyNetWildcardSSLCert }}
-    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
-    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled: "true"
-    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "300"
-spec:
-  ports:
-  - port: 80
-    protocol: TCP
-    name: http
-    targetPort: nginx-http
-  - port: 443
-    protocol: TCP
-    name: https
-    targetPort: nginx-https
-  selector:
-    app: aprd
-    layer: application
-    component: web
-  sessionAffinity: None
-  type: LoadBalancer
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Follow-up to https://github.com/artsy/aprd/pull/116

## Migration

1) Update DNS records for arpd.artsy.net / aprd-staging.artsy.net and wait TTL for DNS propagation (2 hours) 

2) Merge and deploy this PR

3) Delete the "aprd-web" service
- Staging:https://kubernetes-staging.artsy.net/#!/service/default/aprd-web?namespace=default
- Production: https://kubernetes.artsy.net/#!/service/default/aprd-web?namespace=default

See docs in https://www.notion.so/artsy/Nginx-Ingress-Controllers-4b5d937f0acd480f938c34ef1509d3c4 section **Migrating an application from an external LoadBalancer-fronted service to an Ingress-fronted service**