### PR TITLE
Update node affinity.

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -43,16 +43,6 @@ spec:
                 operator: In
                 values:
                 - foreground
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            preference:
-              matchExpressions:
-              - key: tier
-                operator: In
-                values:
-                - foreground
 
 ---
 apiVersion: v1

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -43,16 +43,6 @@ spec:
                 operator: In
                 values:
                 - foreground
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            preference:
-              matchExpressions:
-              - key: tier
-                operator: In
-                values:
-                - foreground
 
 ---
 apiVersion: v1


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-2744

The 2nd affinity block looks redundant. Would like to remove.

Interestingly, it's the 2nd one that is in effect:

```
jian@artsy:~$ kubectl --context production get deployment aprd-web -o yaml | grep -A 10 affinity:
      affinity:
        nodeAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - preference:
              matchExpressions:
              - key: tier
                operator: In
                values:
                - foreground
            weight: 1
      containers:
```