### PR TITLE
fix: replace docker-compose extends keyword with Jinja2 template

### DIFF
--- a/hokusai/build.yml
+++ b/hokusai/build.yml
@@ -2,7 +2,4 @@
 version: '2'
 services:
   aprd:
-    build:
-      context: ../
-      args:
-        SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+{% include 'templates/docker-compose-service.yml.j2' %}

--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -2,9 +2,7 @@
 version: "2"
 services:
   aprd:
-    extends:
-      file: build.yml
-      service: aprd
+{% include 'templates/docker-compose-service.yml.j2' %}
     env_file: ../.env
     environment:
     - DB_HOST=aprd-db

--- a/hokusai/templates/docker-compose-service.yml.j2
+++ b/hokusai/templates/docker-compose-service.yml.j2
@@ -1,0 +1,4 @@
+    build:
+      context: ../
+      args:
+        SECRET_KEY_BASE: ${SECRET_KEY_BASE}

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -3,9 +3,7 @@ version: '2'
 services:
   aprd:
     command: ./hokusai/ci.sh
-    extends:
-      file: build.yml
-      service: aprd
+{% include 'templates/docker-compose-service.yml.j2' %}
     environment:
     - MIX_ENV=test
     - DB_HOST=aprd-db


### PR DESCRIPTION
Required for Docker Compose v3 / Hokusai >= v0.5.12 compatibility