### PR TITLE
 Include additional slack notifications in BNMO Fraud channel

### DIFF
--- a/lib/apr/views/commerce/commerce_order_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_order_slack_view.ex
@@ -14,11 +14,12 @@ defmodule Apr.Views.CommerceOrderSlackView do
 
   def render(subscription, event, routing_key) do
     case {subscription.theme, event["verb"], event["properties"]} do
-      {"fraud", "submitted", %{"mode" => "buy", "items_total_cents" => cents}} when cents >= 3_000_00 ->
-        generate_slack_message(event, routing_key)
-      {"fraud", "approved", %{"mode" => "offer", "currency_code" => currency_code, "items_total_cents" => cents}}
-        when cents >= 9_500_00 and (currency_code == "EUR" or currency_code == "GBP") ->
-        generate_slack_message(event, routing_key)
+      {"fraud", "submitted", %{"mode" => "buy", "decline_code" => decline_code, "items_total_cents" => cents}} 
+        when cents >= 9_500_00 and decline_code != "insufficient_funds" ->        
+          generate_slack_message(event, routing_key)
+      {"fraud", "approved", %{"mode" => "offer", "decline_code" => decline_code, "items_total_cents" => cents}} 
+        when cents >= 9_500_00 and decline_code != "insufficient_funds" ->
+          generate_slack_message(event, routing_key)
         # When subscription theme is not fraud it is nil, in this case we want to render all the messages
       {nil, _, _} ->
         generate_slack_message(event, routing_key)

--- a/lib/apr/views/commerce/commerce_transaction_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_transaction_slack_view.ex
@@ -55,7 +55,7 @@ defmodule Apr.Views.CommerceTransactionSlackView do
           fields:
             [
               %{
-                title: "#{order["mode"]} / #{order["fulfillment_type"]}",
+                title: "#{order["is_inquiry_order"] && "make-offer-inquiry" || order["mode"]} / #{order["fulfillment_type"]}",
                 value:
                   format_price(
                     order["items_total_cents"],

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -127,7 +127,7 @@ defmodule Apr.Fixtures do
       "verb" => "created",
       "properties" => %{
         "order" => order,
-        "failure_code" => "insufficient_funds",
+        "failure_code" => "do_not_honor",
         "failure_message" => ":(",
         "transaction_type" => "capture"
       }


### PR DESCRIPTION
[PURCHASE-2541]

This is my first time working in aprd/elixir, so please let me know if this approach is totally wrong! 

Currently, we're only monitoring approved "buy now" orders above 10k in the #bnmo-fraud channel for AML. We'll also need to include any approved "make offer" orders above 10k USD in the same channel for the same purposes! Format should be similar to what it looks like right now in stripe for the above. 

- Insufficient funds should not be a slack alert as they don’t pose a fraud risk

- Remove the 3k threshold for review

- Mark Make-Offer-Inquiry as such in the channel

Hey @ashkan18 I learned elixir (kinda)!

[PURCHASE-2541]: https://artsyproduct.atlassian.net/browse/PURCHASE-2541