### PR TITLE
feat: show inquiry offer in commerce Slack notifications (PURCHASE-2734)

### DIFF
--- a/lib/apr/views/commerce/commerce_order_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_order_slack_view.ex
@@ -11,12 +11,12 @@ defmodule Apr.Views.CommerceOrderSlackView do
   def render(nil, event, routing_key) do
     generate_slack_message(event, routing_key)
   end
-  
+
   def render(subscription, event, routing_key) do
     case {subscription.theme, event["verb"], event["properties"]} do
-      {"fraud", "submitted", %{"mode" => "buy", "items_total_cents" => cents}} when cents >= 3_000_00 ->        
+      {"fraud", "submitted", %{"mode" => "buy", "items_total_cents" => cents}} when cents >= 3_000_00 ->
         generate_slack_message(event, routing_key)
-      {"fraud", "approved", %{"mode" => "offer", "currency_code" => currency_code, "items_total_cents" => cents}} 
+      {"fraud", "approved", %{"mode" => "offer", "currency_code" => currency_code, "items_total_cents" => cents}}
         when cents >= 9_500_00 and (currency_code == "EUR" or currency_code == "GBP") ->
         generate_slack_message(event, routing_key)
         # When subscription theme is not fraud it is nil, in this case we want to render all the messages
@@ -154,7 +154,7 @@ defmodule Apr.Views.CommerceOrderSlackView do
     [
       %{
         title: "Purchase Method",
-        value: order_properties["mode"],
+        value: purchase_method(order_properties),
         short: true
       },
       %{
@@ -168,6 +168,13 @@ defmodule Apr.Views.CommerceOrderSlackView do
         short: true
       }
     ]
+  end
+
+  defp purchase_method(order) do
+    cond do
+      order["mode"] == "offer" && order["impulse_conversation_id"] -> "Inquiry Offer :cashmoney:"
+      true -> order["mode"]
+    end
   end
 
   defp artworks_links_from_line_items(line_items) do

--- a/test/apr/views/commerce/commerce_order_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_order_slack_view_test.exs
@@ -30,6 +30,15 @@ defmodule Apr.Views.CommerceOrderSlackViewTest do
     assert slack_view[:unfurl_links] == true
   end
 
+  test "submitted inquiry offer order" do
+    event = Fixtures.commerce_offer_order("submitted", %{"impulse_conversation_id" => "12345"})
+    slack_view = CommerceOrderSlackView.render(@subscription, event, "order.submitted")
+    assert slack_view.text == "🤞 Offer Submitted <https://www.artsy.net/artwork/artwork1| >"
+    attachments = slack_view.attachments |> Enum.flat_map(fn a -> a.fields end) |> Enum.map(fn field -> field.value end)
+    assert "Inquiry Offer :cashmoney:" in attachments
+    assert slack_view[:unfurl_links] == true
+  end
+
   test "approved order" do
     event = Fixtures.commerce_order_event("approved")
     slack_view = CommerceOrderSlackView.render(@subscription, event, "order.approved")

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -93,6 +93,7 @@ defmodule Apr.Fixtures do
       "properties" =>
         %{
           "mode" => "buy",
+          "impulse_conversation_id" => nil,
           "state_reason" => nil,
           "seller_id" => "partner1",
           "seller_type" => "gallery",


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PURCHASE-2734

Depends on https://github.com/artsy/exchange/pull/748.

This displays inquiry offer as the purchase method in commerce slack notifications based on the presence of the `impulse_conversaiont_id`.

The "Available Purchase Modes" can be improved separately to say something like "Inquiry".

A preview of the notification looks like:

![Screen Shot 2021-06-04 at 4 15 49 PM](https://user-images.githubusercontent.com/796573/120858754-3bb9fe80-c551-11eb-9892-7247b2727907.png)
