### PR TITLE
fix: limit active_orders to 3-month look-back.

### DIFF
--- a/lib/apr/events.ex
+++ b/lib/apr/events.ex
@@ -187,6 +187,7 @@ defmodule Apr.Events do
         where: fragment("e0.id in (
               select distinct on (payload->'object'->> 'id') id
               from events as last_event
+              where last_event.inserted_at > now() - interval '3 months'
               order by last_event.payload->'object'->> 'id', last_event.inserted_at desc)")
 
     query


### PR DESCRIPTION
https://artsy.slack.com/archives/CA8SANW3W/p1625773570085400
https://artsyproduct.atlassian.net/browse/PLATFORM-3432

I was looking into why `prod-shared` RDS instance's IOPS allowance (300) constantly depletes (see slack thread), and came upon this query.

Manually querying in `psql` shows it's very expensive and it sometimes takes minutes to return. It seems most of the delay is in the sub-query which examines all the stored events. By limiting the query to events within the past few months, it completes a lot quicker. Here's a comparison of query time between the query as it is now and a 6-month-limited-version.

```
bash-5.1# diff -u sql.all.result sql.6mth.result 
--- sql.all.result
+++ sql.6mth.result
@@ -39,10 +39,6 @@
  815191 | order.submitted | 2021-05-24 11:58:08
  673196 | order.submitted | 2021-02-19 01:02:55
  673147 | order.submitted | 2021-02-19 00:41:21
-   5662 | order.submitted | 2019-09-14 21:19:38 <--- 6 month limit misses this order and the ones below.
-   3866 | order.submitted | 2019-08-08 19:43:15
-   3728 | order.submitted | 2019-08-05 20:16:38
-   3534 | order.submitted | 2019-08-02 16:37:37
-(42 rows)
+(38 rows)
-Time: 176679.315 ms (02:56.679) <--- no time limit, took almost 3min
+Time: 4428.298 ms (00:04.428) <--- limit to past 6 months, took 4s
```
From the discussion, we agreed that there's no need for this query to go so far back in time (we can even limit to 1 month). I go for 3 months in this PR.