### PR TITLE
feat: configure dependabot for security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "hex"
+  - package-ecosystem: "mix"
     directory: "/"
     schedule:
       interval: "daily"
@@ -10,7 +10,7 @@ updates:
       - jpotts244
     reviewers:
       - artsy/purchase-devs
-  - package-ecosystem: npm
+  - package-ecosystem: "npm"
     directory: "/assets"
     schedule:
       interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,13 @@ updates:
       - jpotts244
     reviewers:
       - artsy/purchase-devs
+  - package-ecosystem: npm
+    directory: "/assets"
+    schedule:
+      interval: daily
+    # Limit to 0 to enable only security updates:
+    open-pull-requests-limit: 0
+    assignees:
+      - jpotts244
+    reviewers:
+      - artsy/purchase-devs

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "hex"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    # Limit to 0 to enable only security updates:
+    open-pull-requests-limit: 0
+    assignees:
+      - jpotts244
+    reviewers:
+      - artsy/purchase-devs

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,16 +7,16 @@ updates:
     # Limit to 0 to enable only security updates:
     open-pull-requests-limit: 0
     assignees:
-      - jpotts244
+      - "jpotts244"
     reviewers:
-      - artsy/purchase-devs
+      - "artsy/purchase-devs"
   - package-ecosystem: "npm"
     directory: "/assets"
     schedule:
-      interval: daily
+      interval: "daily"
     # Limit to 0 to enable only security updates:
     open-pull-requests-limit: 0
     assignees:
-      - jpotts244
+      - "jpotts244"
     reviewers:
-      - artsy/purchase-devs
+      - "artsy/purchase-devs"


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-3573

This enables security alerts for Github-native dependabot and puts it in line with the 🔒 [security alert playbook](https://www.notion.so/artsy/Security-alerts-and-updates-for-repositories-dependabot-114369231d854ce89b104ea0da5d0c65).

Step 1 (already complete): Enable "Dependabot security updates" under the repo's Security & analysis settings.

Step 2 (this PR): Commit a minimal `.github/dependabot.yml` specifying `open-pull-requests-limit: 0` (a hack to enable only security updates, which can't otherwise be configured). Point person has been made the assignee with associated team as reviewers.

> NOTE: I did not see any private dependencies in this project. If I overlooked, please let me know. 🙇 