### PR TITLE
Kajatiger/px 4623 slack notification to order interventions channel if quotes cant be generated [WIP]

### DIFF
--- a/lib/apr/views/commerce/commerce_disqualified_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_disqualified_slack_view.ex
@@ -1,0 +1,35 @@
+defmodule Apr.Views.CommerceDisqualifiedSlackView do
+    import Apr.Views.Helper
+    alias Apr.Subscriptions.Subscription
+  
+    def render(%Subscription{theme: "fraud"}, _, _), do: nil
+  
+    def render(_, event, _routing_key) do
+      default_message(event)
+    end
+  
+    defp default_message(event) do
+      %{
+        text: ":alert: Shipping Quote Request disqualified from ARTA",
+        attachments: [
+          %{
+            fields:
+              [
+                %{
+                  title: "Type",
+                  value: event["properties"]["type"],
+                  short: true
+                },
+                %{
+                  title: "Code",
+                  value: event["properties"]["code"],
+                  short: true
+                }
+              ]
+          }
+        ],
+        unfurl_links: true
+      }
+    end  
+  end
+  

--- a/lib/apr/views/commerce_slack_view.ex
+++ b/lib/apr/views/commerce_slack_view.ex
@@ -3,7 +3,8 @@ defmodule Apr.Views.CommerceSlackView do
     CommerceTransactionSlackView,
     CommerceOfferSlackView,
     CommerceOrderSlackView,
-    CommerceErrorSlackView
+    CommerceErrorSlackView,
+    CommerceDisqualifiedSlackView
   }
 
   def render(subscription, event, routing_key) do
@@ -19,6 +20,9 @@ defmodule Apr.Views.CommerceSlackView do
 
       routing_key =~ "error." ->
         CommerceErrorSlackView.render(subscription, event, routing_key)
+      
+      routing_key =~ "disqualified." ->
+        CommerceDisqualifiedSlackView.render(subscription, event, routing_key)
 
       true ->
         nil


### PR DESCRIPTION
Resolves: [PX-4623](https://artsyproduct.atlassian.net/browse/PX-4623)

Following up https://github.com/artsy/exchange/pull/1000 we are now adding a subscription to this event in APRD that will trigger a slack notification.