### PR TITLE
feat: make it easy to run the tests in local

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,9 @@ $ git clone git@github.com:artsy/aprd.git
     ```
     $ brew services start postgresql
     $ brew services start rabbitmq
-    ```  
+    ```
 - Install dependencies with `mix deps.get`
-- Go to the config/test.exs file and comment out the lines for the username and password to run the tests: 
-  ```
-  config :apr, Apr.Repo,
-  database: "aprd_test",
-  # username: System.get_env("DB_USER") || "postgres",
-  # password: System.get_env("DB_PASSWORD") || "postgres",
-  hostname: System.get_env("DB_HOST") || "localhost",
-  adapter: Ecto.Adapters.Postgres,
-  pool: Ecto.Adapters.SQL.Sandbox
-  ```
-- In your command line run 
+- In your command line run
   ```
   brew install autoconf@2.69 && \
   brew link --overwrite autoconf@2.69 && \

--- a/config/test.exs
+++ b/config/test.exs
@@ -19,8 +19,6 @@ config :apr,
 # Configure your database
 config :apr, Apr.Repo,
   database: "aprd_test",
-  username: System.get_env("DB_USER") || "postgres",
-  password: System.get_env("DB_PASSWORD") || "postgres",
   hostname: System.get_env("DB_HOST") || "localhost",
   adapter: Ecto.Adapters.Postgres,
   pool: Ecto.Adapters.SQL.Sandbox

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -7,6 +7,8 @@ services:
     environment:
     - MIX_ENV=test
     - DB_HOST=aprd-db
+    - PGUSER=postgres
+    - PGPASSWORD=postgres
     - RABBITMQ_HOST=aprd-rabbitmq
     - RABBITMQ_USER=guest
     - RABBITMQ_PASSWORD=guest


### PR DESCRIPTION
# Summary

The PR allows you to run the tests in your local without commenting out [these two lines](https://github.com/artsy/aprd/pull/273/files#diff-ed81daa10b4c544ac7cd93900fe769744492126448488fa29aec877f408b9403L22-L23). Instead of setting `DB_USER` and `DB_PASSWORD`, now, you can put `PGUSER` and `PGPASSWORD` environment variables to your `.env` file if you want to specify the username and password for Postgresql. 

# How to test

* Check `mix test` doesn't show any error
* Check the tests in CI pass