### PR TITLE
Update reviewers for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     assignees:
       - "jpotts244"
     reviewers:
-      - "artsy/purchase-devs"
+      - "artsy/transact-devs"
   - package-ecosystem: "npm"
     directory: "/assets"
     schedule:
@@ -19,4 +19,4 @@ updates:
     assignees:
       - "jpotts244"
     reviewers:
-      - "artsy/purchase-devs"
+      - "artsy/transact-devs"


### PR DESCRIPTION
This updates the reviewers/assignee for the automated dependency update PRs from dependabot, based on the [Slack thread](https://artsy.slack.com/archives/C02JHHHKP5K/p1655220087502039).