### PR TITLE
feat: notify high risk theme slack subscriptions for approved orders over 10K

### DIFF
--- a/lib/apr/views/commerce/commerce_order_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_order_slack_view.ex
@@ -14,13 +14,16 @@ defmodule Apr.Views.CommerceOrderSlackView do
 
   def render(subscription, event, routing_key) do
     case {subscription.theme, event["verb"], event["properties"]} do
-      {"fraud", "submitted", %{"mode" => "buy", "decline_code" => decline_code, "items_total_cents" => cents}} 
-        when cents >= 9_500_00 and decline_code != "insufficient_funds" ->        
-          generate_slack_message(event, routing_key)
-      {"fraud", "approved", %{"mode" => "offer", "decline_code" => decline_code, "items_total_cents" => cents}} 
+      {"fraud", "submitted", %{"mode" => "buy", "decline_code" => decline_code, "items_total_cents" => cents}}
         when cents >= 9_500_00 and decline_code != "insufficient_funds" ->
           generate_slack_message(event, routing_key)
-        # When subscription theme is not fraud it is nil, in this case we want to render all the messages
+      {"fraud", "approved", %{"mode" => "offer", "decline_code" => decline_code, "items_total_cents" => cents}}
+        when cents >= 9_500_00 and decline_code != "insufficient_funds" ->
+          generate_slack_message(event, routing_key)
+      {"high_risk", "approved", %{"items_total_cents" => cents}}
+        when cents >= 10_000_00 ->
+          generate_slack_message(event, routing_key)
+      # When subscription theme is not fraud it is nil, in this case we want to render all the messages
       {nil, _, _} ->
         generate_slack_message(event, routing_key)
       _ -> nil

--- a/test/apr/views/commerce/commerce_order_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_order_slack_view_test.exs
@@ -158,4 +158,40 @@ defmodule Apr.Views.CommerceOrderSlackViewTest do
 
     assert is_nil(slack_view)
   end
+
+  describe "high risk theme" do
+    setup [:high_risk_theme_subscription]
+
+    test "returns a message for an approved buy order over 10K", context do
+      event = Fixtures.commerce_order_event("approved", %{"items_total_cents" => 10000_00, "currency_code" => "USD", "mode" => "buy"})
+      slack_view = CommerceOrderSlackView.render(context[:subscription], event, "order.approved")
+
+      refute is_nil(slack_view)
+    end
+
+    test "returns a message for an approved offer order over 10K", context do
+      event = Fixtures.commerce_order_event("approved", %{"items_total_cents" => 10000_00, "currency_code" => "USD", "mode" => "offer"})
+      slack_view = CommerceOrderSlackView.render(context[:subscription], event, "order.approved")
+
+      refute is_nil(slack_view)
+    end
+
+    test "does not return a message for an approved buy order under 10K ", context do
+      event = Fixtures.commerce_order_event("approved", %{"items_total_cents" => 9999_00, "currency_code" => "USD", "mode" => "buy"})
+      slack_view = CommerceOrderSlackView.render(context[:subscription], event, "order.approved")
+
+      assert is_nil(slack_view)
+    end
+
+    test "does not return a message for an approved offer order under 10K ", context do
+      event = Fixtures.commerce_order_event("approved", %{"items_total_cents" => 9999_00, "currency_code" => "USD", "mode" => "offer"})
+      slack_view = CommerceOrderSlackView.render(context[:subscription], event, "order.approved")
+
+      assert is_nil(slack_view)
+    end
+  end
+
+  defp high_risk_theme_subscription(_context) do
+    [subscription: %Subscription{theme: "high_risk"}]
+  end
 end


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/TX-204

This adds a `high_risk` subscription theme (in addition to the `fraud` theme we have now) and notifies subscribers for orders (both BN and MO) over 10K. (Currently it's regardless of currency, given the supported currency, and we can be more precise when we support more currencies).

The subscribe to this notification, do the following command in a Slack channel:

```
/apr subscribe commerce:order.approved->high_risk
```

![Screen Shot 2022-06-27 at 12 18 11 AM](https://user-images.githubusercontent.com/796573/175859120-3003947d-4722-4857-aa6f-2a7e413bda83.png)

