### PR TITLE
fix: fix error on building a docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM bitwalker/alpine-elixir-phoenix:1.10.3
 
 ARG SECRET_KEY_BASE
 
-RUN apk add yarn
+RUN apk add yarn --force-broken-world
 
 RUN mkdir /app
 ADD . /app


### PR DESCRIPTION
# Summary

[The main branch is broken](https://app.circleci.com/pipelines/github/artsy/aprd/1802/workflows/47ae9e90-e382-45aa-b38a-494e89404f89/jobs/1464) due to the following error:

```
 > [ 3/11] RUN apk add yarn:
#5 0.216 fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/main/x86_64/APKINDEX.tar.gz
#5 0.405 fetch http://dl-cdn.alpinelinux.org/alpine/v3.11/community/x86_64/APKINDEX.tar.gz
#5 0.505 fetch http://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz
#5 0.612 ERROR: http://dl-cdn.alpinelinux.org/alpine/edge/main: UNTRUSTED signature
#5 0.612 WARNING: Ignoring APKINDEX.066df28d.tar.gz: No such file or directory
#5 0.649 WARNING: The repository tag for world dependency 'pcre@edge' does not exist
#5 0.649 ERROR: Not committing changes due to missing repository tags. Use --force-broken-world to override.
```

This PR fixes the error by following the error message `Use --force-broken-world to override.`.

# How to test

* Run `docker build .`

# Issue

* https://app.circleci.com/pipelines/github/artsy/aprd/1802/workflows/47ae9e90-e382-45aa-b38a-494e89404f89/jobs/1464