### PR TITLE
fix: fix the "logger:remove_handler(default) failed" error

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Apr.MixProject do
   def application do
     [
       mod: {Apr.Application, []},
-      extra_applications: [:logger, :runtime_tools]
+      extra_applications: [:lager, :logger, :runtime_tools]
     ]
   end
 


### PR DESCRIPTION
# Summary

When I executed `mix test` to run the tests, I got the following error.

```
[error] calling logger:remove_handler(default) failed: :error {:badmatch, {:error, {:not_found, :default}}}
```

In order to fix the error, I tried this: https://github.com/erlang-lager/lager/issues/507#issuecomment-570378407j
and it works even though I don't understand why it works in the CI without the change.

# How to test

Execute `mix test` to make sure you can run tests without the error