### PR TITLE
feat: send "Seller's stripe account will be restricted" notification to seller channel

### DIFF
--- a/lib/apr/application.ex
+++ b/lib/apr/application.ex
@@ -65,6 +65,10 @@ defmodule Apr.Application do
       %{
         id: :partners,
         start: {Apr.AmqEventService, :start_link, [%{topic: "partners"}]}
+      },
+      %{
+        id: :sellers,
+        start: {Apr.AmqEventService, :start_link, [%{topic: "sellers", store: true}]}
       }
     ]
 

--- a/lib/apr/notifications.ex
+++ b/lib/apr/notifications.ex
@@ -32,7 +32,7 @@ defmodule Apr.Notifications do
           Apr.Views.ConversationSlackView.render(subscription, event)
 
         "invoices" ->
-          Apr.Views.InvoiceSlackView.render(subscription, event, routing_key)
+          Apr.Views.SellerSlackView.render(subscription, event, routing_key)
 
         "consignments" ->
           Apr.Views.ConsignmentsSlackView.render(subscription, event)

--- a/lib/apr/notifications.ex
+++ b/lib/apr/notifications.ex
@@ -31,7 +31,7 @@ defmodule Apr.Notifications do
         "conversations" ->
           Apr.Views.ConversationSlackView.render(subscription, event)
 
-        "invoices" ->
+        "sellers" ->
           Apr.Views.SellerSlackView.render(subscription, event, routing_key)
 
         "consignments" ->

--- a/lib/apr/views/seller_slack_view.ex
+++ b/lib/apr/views/seller_slack_view.ex
@@ -6,11 +6,11 @@ defmodule Apr.Views.SellerSlackView do
     partner_data = fetch_partner_data(event["properties"]["partner_id"])
 
     cond do
+      routing_key == "merchantaccount.external_account_restricted_soon" ->
+        external_account_restricted_soon_message(event, partner_data)
+
       routing_key =~ "merchantaccount" ->
-        case event["verb"] do
-          "external_account_restricted_soon" -> external_account_restricted_soon_message(event, partner_data)
-          _ -> merchant_account_message(event, partner_data)
-        end
+        merchant_account_message(event, partner_data)
 
       routing_key =~ "invoicetransaction" ->
         invoice_transaction_message(event, partner_data)

--- a/lib/apr/views/seller_slack_view.ex
+++ b/lib/apr/views/seller_slack_view.ex
@@ -7,7 +7,10 @@ defmodule Apr.Views.SellerSlackView do
 
     cond do
       routing_key =~ "merchantaccount" ->
-        merchant_account_message(event, partner_data)
+        case event["verb"] do
+          "external_account_restricted_soon" -> external_account_restricted_soon_message(event, partner_data)
+          _ -> merchant_account_message(event, partner_data)
+        end
 
       routing_key =~ "invoicetransaction" ->
         invoice_transaction_message(event, partner_data)
@@ -19,6 +22,34 @@ defmodule Apr.Views.SellerSlackView do
 
   defp fetch_partner_data(partner_id) do
     @gravity_api.get!("/partners/#{partner_id}").body
+  end
+
+  defp external_account_restricted_soon_message(event, partner_data) do
+    {:ok, due_date} = DateTime.from_unix(event["properties"]["stripe_requirements"]["deadline"])
+    %{
+      text: ":warning: Stripe account of #{partner_data["name"]} will be restricted by #{NimbleStrftime.format(due_date, "%Y-%m-%d %I:%M %p %Z")}",
+      attachments: [
+        %{
+          fields: [
+            %{
+              title: "Requirements",
+              value: Enum.join(event["properties"]["stripe_requirements"]["requirements"], ", "),
+              short: true
+            },
+            %{
+              title: "Stripe account ID",
+              value: formatted_stripe_account_link(event["properties"]["external_id"]),
+              short: true
+            }
+          ]
+        }
+      ],
+      unfurl_links: true
+    }
+  end
+
+  defp formatted_stripe_account_link(stripe_account_id) do
+    "<https://dashboard.stripe.com/connect/accounts/#{stripe_account_id}/activity|#{stripe_account_id}>"
   end
 
   defp merchant_account_message(event, partner_data) do

--- a/lib/apr/views/seller_slack_view.ex
+++ b/lib/apr/views/seller_slack_view.ex
@@ -1,4 +1,4 @@
-defmodule Apr.Views.InvoiceSlackView do
+defmodule Apr.Views.SellerSlackView do
   @gravity_api Application.get_env(:apr, :gravity_api)
   import Apr.Views.Helper
 

--- a/test/apr/seller_slack_view_test.exs
+++ b/test/apr/seller_slack_view_test.exs
@@ -11,6 +11,40 @@ defmodule Apr.Views.SellerSlackViewTest do
       assert slack_view.text == ":money_with_wings: Invoice Transaction(123)"
     end
 
+    test "merchant_account event with test routing_key" do
+      event = Apr.Fixtures.invoice_event(
+        "external_account_restricted_soon",
+        %{
+          "stripe_requirements" => %{
+            "deadline" => 1_546_300_800,
+            "requirements" => ["external_account"]
+          }
+        }
+      )
+      slack_view = SellerSlackView.render(nil, event, "merchantaccount")
+
+      assert slack_view == %{
+        attachments: [
+          %{
+            fields: [
+              %{
+                short: true,
+                title: "Requirements",
+                value: "external_account"
+              },
+              %{
+                short: true,
+                title: "Stripe account ID",
+                value: "<https://dashboard.stripe.com/connect/accounts/stripe_account_id/activity|stripe_account_id>"
+              }
+            ]
+          }
+        ],
+        text: ":warning: Stripe account of Mocked Partner2 will be restricted by 2019-01-01 12:00 AM UTC",
+        unfurl_links: true
+      }
+    end
+
     test "invoice event with merchantaccount routing_key" do
       event = Apr.Fixtures.invoice_event()
       slack_view = SellerSlackView.render(nil, event, "merchantaccount")

--- a/test/apr/seller_slack_view_test.exs
+++ b/test/apr/seller_slack_view_test.exs
@@ -1,26 +1,26 @@
-defmodule Apr.Views.InvoiceSlackViewTest do
+defmodule Apr.Views.SellerSlackViewTest do
   use ExUnit.Case, async: true
-  alias Apr.Views.InvoiceSlackView
+  alias Apr.Views.SellerSlackView
   import Mox
 
   describe "render/3" do
     test "invoice event with test routing_key" do
       event = Apr.Fixtures.invoice_event()
-      slack_view = InvoiceSlackView.render(nil, event, "test")
+      slack_view = SellerSlackView.render(nil, event, "test")
 
       assert slack_view.text == ":money_with_wings: Invoice Transaction(123)"
     end
 
     test "invoice event with merchantaccount routing_key" do
       event = Apr.Fixtures.invoice_event()
-      slack_view = InvoiceSlackView.render(nil, event, "merchantaccount")
+      slack_view = SellerSlackView.render(nil, event, "merchantaccount")
 
       assert slack_view.text == ":party-parrot: Mocked Partner2 merchant account created"
     end
 
     test "invoice event invoicetransaction routing_key" do
       event = Apr.Fixtures.invoice_event()
-      slack_view = InvoiceSlackView.render(nil, event, "invoicetransaction")
+      slack_view = SellerSlackView.render(nil, event, "invoicetransaction")
 
       assert slack_view.text == ":oncoming_police_car: "
     end

--- a/test/apr/seller_slack_view_test.exs
+++ b/test/apr/seller_slack_view_test.exs
@@ -11,7 +11,7 @@ defmodule Apr.Views.SellerSlackViewTest do
       assert slack_view.text == ":money_with_wings: Invoice Transaction(123)"
     end
 
-    test "merchant_account event with test routing_key" do
+    test "merchant_account event with external_account_restricted_soon routing_key" do
       event = Apr.Fixtures.seller_event(
         "external_account_restricted_soon",
         %{
@@ -21,7 +21,7 @@ defmodule Apr.Views.SellerSlackViewTest do
           }
         }
       )
-      slack_view = SellerSlackView.render(nil, event, "merchantaccount")
+      slack_view = SellerSlackView.render(nil, event, "merchantaccount.external_account_restricted_soon")
 
       assert slack_view == %{
         attachments: [

--- a/test/apr/seller_slack_view_test.exs
+++ b/test/apr/seller_slack_view_test.exs
@@ -4,15 +4,15 @@ defmodule Apr.Views.SellerSlackViewTest do
   import Mox
 
   describe "render/3" do
-    test "invoice event with test routing_key" do
-      event = Apr.Fixtures.invoice_event()
+    test "seller event with test routing_key" do
+      event = Apr.Fixtures.seller_event()
       slack_view = SellerSlackView.render(nil, event, "test")
 
       assert slack_view.text == ":money_with_wings: Invoice Transaction(123)"
     end
 
     test "merchant_account event with test routing_key" do
-      event = Apr.Fixtures.invoice_event(
+      event = Apr.Fixtures.seller_event(
         "external_account_restricted_soon",
         %{
           "stripe_requirements" => %{
@@ -45,15 +45,15 @@ defmodule Apr.Views.SellerSlackViewTest do
       }
     end
 
-    test "invoice event with merchantaccount routing_key" do
-      event = Apr.Fixtures.invoice_event()
+    test "seller event with merchantaccount routing_key" do
+      event = Apr.Fixtures.seller_event()
       slack_view = SellerSlackView.render(nil, event, "merchantaccount")
 
       assert slack_view.text == ":party-parrot: Mocked Partner2 merchant account created"
     end
 
-    test "invoice event invoicetransaction routing_key" do
-      event = Apr.Fixtures.invoice_event()
+    test "seller event invoicetransaction routing_key" do
+      event = Apr.Fixtures.seller_event()
       slack_view = SellerSlackView.render(nil, event, "invoicetransaction")
 
       assert slack_view.text == ":oncoming_police_car: "

--- a/test/apr/views/invoice_slack_view_test.exs
+++ b/test/apr/views/invoice_slack_view_test.exs
@@ -1,0 +1,28 @@
+defmodule Apr.Views.InvoiceSlackViewTest do
+  use ExUnit.Case, async: true
+  alias Apr.Views.InvoiceSlackView
+  import Mox
+
+  describe "render/3" do
+    test "invoice event with test routing_key" do
+      event = Apr.Fixtures.invoice_event()
+      slack_view = InvoiceSlackView.render(nil, event, "test")
+
+      assert slack_view.text == ":money_with_wings: Invoice Transaction(123)"
+    end
+
+    test "invoice event with merchantaccount routing_key" do
+      event = Apr.Fixtures.invoice_event()
+      slack_view = InvoiceSlackView.render(nil, event, "merchantaccount")
+
+      assert slack_view.text == ":party-parrot: Mocked Partner2 merchant account created"
+    end
+
+    test "invoice event invoicetransaction routing_key" do
+      event = Apr.Fixtures.invoice_event()
+      slack_view = InvoiceSlackView.render(nil, event, "invoicetransaction")
+
+      assert slack_view.text == ":oncoming_police_car: "
+    end
+  end
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -234,7 +234,7 @@ defmodule Apr.Fixtures do
     }
   end
 
-  def invoice_event do
+  def invoice_event(verb \\ "created", properties \\ %{}) do
     %{
       "object" => %{
         "id" => "transaction123",
@@ -244,14 +244,16 @@ defmodule Apr.Fixtures do
         "id" => "user1",
         "display" => "User LastName"
       },
-      "verb" => "created",
+      "verb" => verb,
       "properties" => %{
         "partner_id" => "1",
         "artwork_groups" => [],
         "invoice" => %{
           "artwork_groups" => []
-        }
+        },
+        "external_id" => "stripe_account_id",
       }
+      |> Map.merge(properties)
     }
   end
 end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -234,7 +234,7 @@ defmodule Apr.Fixtures do
     }
   end
 
-  def invoice_event(verb \\ "created", properties \\ %{}) do
+  def seller_event(verb \\ "created", properties \\ %{}) do
     %{
       "object" => %{
         "id" => "transaction123",

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -233,4 +233,25 @@ defmodule Apr.Fixtures do
       }
     }
   end
+
+  def invoice_event do
+    %{
+      "object" => %{
+        "id" => "transaction123",
+        "display" => "Transaction(123)"
+      },
+      "subject" => %{
+        "id" => "user1",
+        "display" => "User LastName"
+      },
+      "verb" => "created",
+      "properties" => %{
+        "partner_id" => "1",
+        "artwork_groups" => [],
+        "invoice" => %{
+          "artwork_groups" => []
+        }
+      }
+    }
+  end
 end

--- a/test/support/gravity_mock.ex
+++ b/test/support/gravity_mock.ex
@@ -18,6 +18,15 @@ defmodule GravityMock do
     }
   end
 
+  def get!("/partners/" <> id) do
+    %{
+      body: %{
+        "id" => id,
+        "name" => "Mocked Partner2"
+      }
+    }
+  end
+
   def get!("/v1/artwork/" <> artwork_id) do
     %{
       body: %{


### PR DESCRIPTION
# Summary

The PR migrates `Apr.Views.InvoiceSlackView` to `Apr.Views.SellerSlackView` and sends "The seller's stripe account will be restricted by the due date" notification to the channel that subscribes to the `seller` topic. 

# Todo

* [ ] Tag Andrew Boos to the message once we can show the message on slack
* [x] Create new sellers topic in staging and production: `Apr.Subscriptions.create_topic(%{name: "sellers"})`

# Ticket

https://artsyproduct.atlassian.net/browse/TX-763