### PR TITLE
fix: fix links to admin-partners

### DIFF
--- a/lib/apr/views/commerce_transaction_created_slack_view.ex
+++ b/lib/apr/views/commerce_transaction_created_slack_view.ex
@@ -42,7 +42,7 @@ defmodule Apr.Views.CommerceTransactionCreatedSlackView do
   end
 
   defp formatted_admin_partners_link(seller_id) do
-    seller_path = "partner/#{seller_id}"
+    seller_path = "partners/#{seller_id}"
     "<#{admin_partners_link(seller_path)}|#{seller_id}>"
   end
 

--- a/test/apr/views/commerce_transaction_created_slack_view_test.exs
+++ b/test/apr/views/commerce_transaction_created_slack_view_test.exs
@@ -35,7 +35,7 @@ defmodule Apr.Views.CommerceTransactionCreatedSlackViewTest do
               %{
                 short: true,
                 title: "Seller ID",
-                value: "<https://admin-partners.artsy.net/partner/partner1|partner1>"
+                value: "<https://admin-partners.artsy.net/partners/partner1|partner1>"
               },
               %{
                 short: true,


### PR DESCRIPTION
Followup on https://github.com/artsy/aprd/pull/352, this fixes the link to admin-partners from our [first notification](https://artsy.slack.com/archives/C02GMJT64LS/p1666202894773179).

![Screen Shot 2022-10-19 at 3 13 40 PM](https://user-images.githubusercontent.com/796573/196783058-3c4337f8-363b-48e2-bec1-26210f44f24f.png)
