### PR TITLE
feat: send notification when async payment order > 10k is processing_approval state

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -7,7 +7,7 @@ use Mix.Config
 # watchers to your application. For example, we use it
 # with webpack to recompile .js and .css sources.
 config :apr, AprWeb.Endpoint,
-  http: [port: 4000],
+  http: [port: 4000, protocol_options: [idle_timeout: 5_000_000]],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,

--- a/config/test.exs
+++ b/config/test.exs
@@ -21,7 +21,8 @@ config :apr, Apr.Repo,
   database: "aprd_test",
   hostname: System.get_env("DB_HOST") || "localhost",
   adapter: Ecto.Adapters.Postgres,
-  pool: Ecto.Adapters.SQL.Sandbox
+  pool: Ecto.Adapters.SQL.Sandbox,
+  ownership_timeout: 999_999_999
 
 config :apr, RabbitMQ,
   username: System.get_env("RABBITMQ_USER") || "guest",

--- a/lib/apr/views/commerce/commerce_order_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_order_slack_view.ex
@@ -24,6 +24,10 @@ defmodule Apr.Views.CommerceOrderSlackView do
       {"high_risk", "approved", %{"items_total_cents" => cents}}
         when cents >= 10_000_00 ->
           generate_slack_message(event, routing_key)
+      {"high_risk_async_payment", "processing_approval", %{"items_total_cents" => cents}}
+        when cents >= 10_000_00 ->
+          # require IEx; IEx.pry
+          generate_slack_message(event, routing_key)
       # When subscription theme is not fraud it is nil, in this case we want to render all the messages
       {nil, _, _} ->
         generate_slack_message(event, routing_key)
@@ -91,6 +95,9 @@ defmodule Apr.Views.CommerceOrderSlackView do
 
       {"pending_fulfillment", _} ->
         ":hourglass: Waiting Shipping"
+
+      {"processing_approval", _} ->
+        ":hourglass: Waiting Payment Processing Approval"
 
       _ ->
         nil

--- a/lib/apr/views/commerce/commerce_order_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_order_slack_view.ex
@@ -26,7 +26,6 @@ defmodule Apr.Views.CommerceOrderSlackView do
           generate_slack_message(event, routing_key)
       {"high_risk_async_payment", "processing_approval", %{"items_total_cents" => cents}}
         when cents >= 10_000_00 ->
-          # require IEx; IEx.pry
           generate_slack_message(event, routing_key)
       # When subscription theme is not fraud it is nil, in this case we want to render all the messages
       {nil, _, _} ->

--- a/test/apr/seller_slack_view_test.exs
+++ b/test/apr/seller_slack_view_test.exs
@@ -1,7 +1,6 @@
 defmodule Apr.Views.SellerSlackViewTest do
   use ExUnit.Case, async: true
   alias Apr.Views.SellerSlackView
-  import Mox
 
   describe "render/3" do
     test "seller event with test routing_key" do

--- a/test/apr/views/commerce/commerce_order_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_order_slack_view_test.exs
@@ -191,7 +191,43 @@ defmodule Apr.Views.CommerceOrderSlackViewTest do
     end
   end
 
+  describe "high risk async_payment theme" do
+    setup [:high_risk_async_payment_theme_subscription]
+
+    test "returns a message for an processing_approval buy order over 10K", context do
+      event = Fixtures.commerce_order_event("processing_approval", %{"items_total_cents" => 10000_00, "currency_code" => "USD", "mode" => "buy"})
+      slack_view = CommerceOrderSlackView.render(context[:subscription], event, "order.processing_approval")
+
+      refute is_nil(slack_view)
+    end
+
+    test "returns a message for an processing_approval offer order over 10K", context do
+      event = Fixtures.commerce_order_event("processing_approval", %{"items_total_cents" => 10000_00, "currency_code" => "USD", "mode" => "offer"})
+      slack_view = CommerceOrderSlackView.render(context[:subscription], event, "order.processing_approval")
+
+      refute is_nil(slack_view)
+    end
+
+    test "does not return a message for an processing_approval buy order under 10K ", context do
+      event = Fixtures.commerce_order_event("processing_approval", %{"items_total_cents" => 9999_00, "currency_code" => "USD", "mode" => "buy"})
+      slack_view = CommerceOrderSlackView.render(context[:subscription], event, "order.processing_approval")
+
+      assert is_nil(slack_view)
+    end
+
+    test "does not return a message for an processing_approval offer order under 10K ", context do
+      event = Fixtures.commerce_order_event("processing_approval", %{"items_total_cents" => 9999_00, "currency_code" => "USD", "mode" => "offer"})
+      slack_view = CommerceOrderSlackView.render(context[:subscription], event, "order.processing_approval")
+
+      assert is_nil(slack_view)
+    end
+  end
+
   defp high_risk_theme_subscription(_context) do
     [subscription: %Subscription{theme: "high_risk"}]
+  end
+
+  defp high_risk_async_payment_theme_subscription(_context) do
+    [subscription: %Subscription{theme: "high_risk_async_payment"}]
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,3 @@
+ExUnit.configure(timeout: :infinity)
 ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(Apr.Repo, :manual)


### PR DESCRIPTION
# Summary

The PR achieve the followings:

* Send the notification when async payment order > 10k is `processing_approval` state
* Disable the timeout in Elixir debug mode with pry

The notification is quite similar with the following `approved` notification: 
![Screenshot 2022-11-09 at 12 59 47](https://user-images.githubusercontent.com/827596/200827841-0c9f1a78-4035-4761-9b6b-3950bbb8afea.png)


# Ticket
https://artsyproduct.atlassian.net/browse/TX-841