### PR TITLE
feat[TX-840]: handle ACH payment failures gracefully

### DIFF
--- a/lib/apr/behaviours/payments_behaviour.ex
+++ b/lib/apr/behaviours/payments_behaviour.ex
@@ -1,3 +1,4 @@
 defmodule Apr.PaymentsBehaviour do
   @callback payment_info(String.t(), String.t()) :: Map.t()
+  @callback payment_info_ach(String.t(), String.t()) :: Map.t()
 end

--- a/test/apr/views/commerce/commerce_transaction_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_transaction_slack_view_test.exs
@@ -19,93 +19,137 @@ defmodule Apr.Views.CommerceTransactionSlackViewTest do
        }}
     end)
 
+    expect(Apr.PaymentsMock, :payment_info_ach, fn _, _ ->
+      {:ok,
+       %{
+         charge_data: %{risk_level: "high"},
+       }}
+    end)
+
     :ok
   end
 
-  test "adds shipping details for orders to be shipped" do
-    event =
-      Apr.Fixtures.commerce_transaction_event(%{
-        "id" => "order123",
-        "items_total_cents" => 2_000_000,
-        "currency_code" => "USD",
-        "seller_id" => "partner1",
-        "seller_type" => "gallery",
-        "buyer_id" => "user1",
-        "buyer_type" => "user",
-        "fulfillment_type" => "ship",
-        "shipping_country" => "US",
-        "shipping_name" => "Art",
-        "mode" => "buy"
-      })
+  describe "credit card transactions" do
+    test "adds shipping details for orders to be shipped" do
+      event =
+        Apr.Fixtures.commerce_transaction_event(%{
+          "id" => "order123",
+          "items_total_cents" => 2_000_000,
+          "currency_code" => "USD",
+          "seller_id" => "partner1",
+          "seller_type" => "gallery",
+          "buyer_id" => "user1",
+          "buyer_type" => "user",
+          "fulfillment_type" => "ship",
+          "shipping_country" => "US",
+          "shipping_name" => "Art",
+          "mode" => "buy",
+          "payment_method" => "credit card"
+        })
 
-    slack_view = CommerceTransactionSlackView.render(@subscription, event, "transaction.failed")
-    titles = slack_view.attachments |> Enum.flat_map(fn a -> a.fields end) |> Enum.map(fn field -> field.title end)
-    assert "buy / ship" in titles
-    assert "CVC Check  :x:" in titles
-    assert "ZIP Check  :x:" in titles
-    assert "Liability Shift :verified:" in titles
-    assert "Shipping Name" in titles
-    assert "Shipping Country" in titles
-    assert "Shipping State" in titles
+      slack_view = CommerceTransactionSlackView.render(@subscription, event, "transaction.failed")
+      titles = slack_view.attachments |> Enum.flat_map(fn a -> a.fields end) |> Enum.map(fn field -> field.title end)
+      assert "buy / ship" in titles
+      assert "CVC Check  :x:" in titles
+      assert "ZIP Check  :x:" in titles
+      assert "Liability Shift :verified:" in titles
+      assert "Shipping Name" in titles
+      assert "Shipping Country" in titles
+      assert "Shipping State" in titles
+    end
+
+    test "Has correct fields for pickup orders" do
+      event =
+        Apr.Fixtures.commerce_transaction_event(%{
+          "id" => "order123",
+          "items_total_cents" => 2_000_000,
+          "currency_code" => "USD",
+          "seller_id" => "partner1",
+          "seller_type" => "gallery",
+          "buyer_id" => "user1",
+          "buyer_type" => "user",
+          "fulfillment_type" => "pickup",
+          "mode" => "buy",
+          "payment_method" => "credit card"
+        })
+
+      slack_view = CommerceTransactionSlackView.render(@subscription, event, "transaction.failed")
+      titles = slack_view.attachments |> Enum.flat_map(fn a -> a.fields end) |> Enum.map(fn field -> field.title end)
+      assert "buy / pickup" in titles
+      assert "CVC Check  :x:" in titles
+      assert "ZIP Check  :x:" in titles
+      assert "Liability Shift :verified:" in titles
+      assert "Shipping Name" not in titles
+      assert "Shipping Country" not in titles
+      assert "Shipping State" not in titles
+    end
+
+    test "doesn't add shipping details for orders without a fulfillment type" do
+      event =
+        Apr.Fixtures.commerce_transaction_event(%{
+          "id" => "order123",
+          "items_total_cents" => 2_000_000,
+          "currency_code" => "USD",
+          "seller_id" => "partner1",
+          "seller_type" => "gallery",
+          "buyer_id" => "user1",
+          "buyer_type" => "user",
+          "payment_method" => "credit card"
+        })
+
+      slack_view = CommerceTransactionSlackView.render(@subscription, event, "transaction.failed")
+      titles = Enum.map(List.first(slack_view.attachments).fields, fn field -> field.title end)
+      assert "Fulfillment Type" not in titles
+      assert "Shipping Country" not in titles
+      assert "Shipping Name" not in titles
+    end
+
+    test "returns message for subscription with fraud template and total cents below threshold" do
+      event =
+        Apr.Fixtures.commerce_transaction_event(%{
+          "id" => "order123",
+          "items_total_cents" => 2001_00,
+          "currency_code" => "USD",
+          "seller_id" => "partner1",
+          "seller_type" => "gallery",
+          "buyer_id" => "user1",
+          "buyer_type" => "user",
+          "payment_method" => "credit card"
+        })
+
+      slack_view = CommerceTransactionSlackView.render(@fraud_theme_subscription, event, "transaction.failed")
+      refute is_nil(slack_view.text)
+    end
   end
 
-  test "Has correct fields for pickup orders" do
-    event =
-      Apr.Fixtures.commerce_transaction_event(%{
-        "id" => "order123",
-        "items_total_cents" => 2_000_000,
-        "currency_code" => "USD",
-        "seller_id" => "partner1",
-        "seller_type" => "gallery",
-        "buyer_id" => "user1",
-        "buyer_type" => "user",
-        "fulfillment_type" => "pickup",
-        "mode" => "buy"
-      })
+  describe "ACH transactions" do
+    test "adds bank account payment information" do
+      event =
+        Apr.Fixtures.commerce_transaction_event(%{
+          "id" => "order123",
+          "items_total_cents" => 2_000_000,
+          "currency_code" => "USD",
+          "seller_id" => "partner1",
+          "seller_type" => "gallery",
+          "buyer_id" => "user1",
+          "buyer_type" => "user",
+          "fulfillment_type" => "ship",
+          "shipping_country" => "US",
+          "shipping_name" => "Art",
+          "mode" => "buy",
+          "payment_method" => "us_bank_account"
+        })
 
-    slack_view = CommerceTransactionSlackView.render(@subscription, event, "transaction.failed")
-    titles = slack_view.attachments |> Enum.flat_map(fn a -> a.fields end) |> Enum.map(fn field -> field.title end)
-    assert "buy / pickup" in titles
-    assert "CVC Check  :x:" in titles
-    assert "ZIP Check  :x:" in titles
-    assert "Liability Shift :verified:" in titles
-    assert "Shipping Name" not in titles
-    assert "Shipping Country" not in titles
-    assert "Shipping State" not in titles
-  end
-
-  test "doesn't add shipping details for orders without a fulfillment type" do
-    event =
-      Apr.Fixtures.commerce_transaction_event(%{
-        "id" => "order123",
-        "items_total_cents" => 2_000_000,
-        "currency_code" => "USD",
-        "seller_id" => "partner1",
-        "seller_type" => "gallery",
-        "buyer_id" => "user1",
-        "buyer_type" => "user"
-      })
-
-    slack_view = CommerceTransactionSlackView.render(@subscription, event, "transaction.failed")
-    titles = Enum.map(List.first(slack_view.attachments).fields, fn field -> field.title end)
-    assert "Fulfillment Type" not in titles
-    assert "Shipping Country" not in titles
-    assert "Shipping Name" not in titles
-  end
-
-  test "returns message for subscription with fraud template and total cents below threshold" do
-    event =
-      Apr.Fixtures.commerce_transaction_event(%{
-        "id" => "order123",
-        "items_total_cents" => 2001_00,
-        "currency_code" => "USD",
-        "seller_id" => "partner1",
-        "seller_type" => "gallery",
-        "buyer_id" => "user1",
-        "buyer_type" => "user"
-      })
-
-    slack_view = CommerceTransactionSlackView.render(@fraud_theme_subscription, event, "transaction.failed")
-    refute is_nil(slack_view.text)
+      slack_view = CommerceTransactionSlackView.render(@subscription, event, "transaction.failed")
+      titles = slack_view.attachments |> Enum.flat_map(fn a -> a.fields end) |> Enum.map(fn field -> field.title end)
+      assert "buy / ship" in titles
+      assert "Risk Level" in titles
+      assert "CVC Check  :x:" not in titles
+      assert "ZIP Check  :x:" not in titles
+      assert "Liability Shift :verified:" not in titles
+      assert "Shipping Name" in titles
+      assert "Shipping Country" in titles
+      assert "Shipping State" in titles
+    end
   end
 end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -173,6 +173,7 @@ defmodule Apr.Fixtures do
           "currency_code" => "USD",
           "items_total_cents" => 2_000_000,
           "total_list_price_cents" => 3000,
+          "payment_method" => "credit card",
           "line_items" => [
             %{
               "id" => "li-1",


### PR DESCRIPTION
We have some baked-in assumptions in our handlers for failed transaction notifications - they assume the transaction was a card transaction, leading to errors like [this one](https://sentry.io/organizations/artsynet/issues/3499164108/events/latest/?project=1776905&query=is%3Aunresolved&statsPeriod=90d#exception).

This change introduces a separate handler for failed ACH payments, forking the logic by payment_type.

Jira ticket: https://artsyproduct.atlassian.net/browse/TX-840