### PR TITLE
feat: support artist_change events on auction_results exchange (DO-505)

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -17,16 +17,27 @@ brew 'yarn'
 EOF
 
 echo "fix rabbitmq stomp plugin not able to bind to port 61613..."
-if ! grep -Fq "stomp.listeners.tcp.1 = 12345" /usr/local/etc/rabbitmq/rabbitmq; then
-  echo "stomp.listeners.tcp.1 = 12345" >> /usr/local/etc/rabbitmq/rabbitmq
+if ! grep -Fq "stomp.listeners.tcp.1 = 12345" $(brew --prefix)/etc/rabbitmq/rabbitmq; then
+  echo "stomp.listeners.tcp.1 = 12345" >> $(brew --prefix)/etc/rabbitmq/rabbitmq
   brew services restart rabbitmq
 fi
 
+if [[ "$SHELL" = *"bash"* ]]; then
+  touch ~/.bash_profile
+  PROFILE="$HOME/.bash_profile"
+elif [[ "$SHELL" = *"zsh"* ]]; then
+  PROFILE="$HOME/.zshrc"
+fi
+
 echo "Setup asdf, if required..."
-if (! grep 'asdf.sh' ~/.bash_profile)
+if (! grep 'asdf.sh' $PROFILE)
 then
-  echo -e "\n. $(brew --prefix asdf)/asdf.sh" >> ~/.bash_profile
-  source ~/.bash_profile
+  echo -e "\n. $(brew --prefix asdf)/asdf.sh" >> $PROFILE
+  if [[ "$SHELL" = *"bash"* ]]; then
+    source $PROFILE
+  elif [[ "$SHELL" = *"zsh"* ]]; then
+    zsh $PROFILE
+  fi
 fi
 
 echo "Prepare asdf for erlang and elixir..."

--- a/lib/apr/application.ex
+++ b/lib/apr/application.ex
@@ -15,6 +15,10 @@ defmodule Apr.Application do
       # Starts a worker by calling: Apr.Worker.start_link(arg)
       # {Apr.Worker, arg},
       %{
+        id: :auction_results,
+        start: {Apr.AmqEventService, :start_link, [%{topic: "auction_results"}]}
+      },
+      %{
         id: :commerce,
         start: {Apr.AmqEventService, :start_link, [%{topic: "commerce", store: true}]}
       },

--- a/lib/apr/notifications.ex
+++ b/lib/apr/notifications.ex
@@ -13,6 +13,9 @@ defmodule Apr.Notifications do
   defp slack_message(subscription, event, topic_name, routing_key) do
     with topic when not is_nil(topic) <- Subscriptions.get_topic_by_name(topic_name) do
       case topic.name do
+        "auction_results" ->
+          Apr.Views.AuctionResultsSlackView.render(subscription, event)
+
         "subscriptions" ->
           Apr.Views.SubscriptionSlackView.render(subscription, event)
 

--- a/lib/apr/views/auction_results_slack_view.ex
+++ b/lib/apr/views/auction_results_slack_view.ex
@@ -1,0 +1,29 @@
+defmodule Apr.Views.AuctionResultsSlackView do
+  import Apr.Views.Helper
+
+  def render(_subscription, event) do
+    case event["verb"] do
+      "artist_change" ->
+        %{
+          text: "Artist match updated for #{event["object"]["display"]} (##{event["object"]["id"]})",
+          attachments: [
+            %{
+              fields: [
+                %{
+                  title: "Old artist id",
+                  value: formatted_artist_link(event["properties"]["old_artist_id"]),
+                  short: true
+                },
+                %{
+                  title: "New artist",
+                  value: formatted_artist_link(event["properties"]["artist_id"], get_in(event, ["properties", "match", "_source", "name"])),
+                  short: true
+                }
+              ]
+            }
+          ],
+          unfurl_links: false
+        }
+    end
+  end
+end

--- a/lib/apr/views/helpers/view_helper.ex
+++ b/lib/apr/views/helpers/view_helper.ex
@@ -24,6 +24,14 @@ defmodule Apr.Views.Helper do
     "https://www.artsy.net/artist/#{artist_id}"
   end
 
+  def formatted_artist_link(artist_id) do
+    "<#{artist_link(artist_id)}|#{artist_id}>"
+  end
+
+  def formatted_artist_link(artist_id, name) do
+    "<#{artist_link(artist_id)}|#{name}>"
+  end
+
   def radiation_link(path) do
     "https://radiation.artsy.net/#{path}"
   end

--- a/test/apr/views/auction_results_slack_view_test.exs
+++ b/test/apr/views/auction_results_slack_view_test.exs
@@ -1,0 +1,35 @@
+defmodule Apr.Views.AuctionResultsSlackViewTest do
+  use ExUnit.Case, async: true
+  alias Apr.Views.AuctionResultsSlackView
+  alias Apr.Fixtures
+
+  describe "artist changed" do
+    test "from one artist to another" do
+      event = Fixtures.auction_results_artist_change_event
+      slack_view = AuctionResultsSlackView.render(nil, event)
+
+      assert slack_view.text == "Artist match updated for The Fall by Richard Bosman, #126 at Christie's: Contemporary Edition (2022-03-09) (#751294)"
+      attachments = slack_view.attachments |> Enum.flat_map(fn a -> a.fields end) |> Enum.map(fn field -> field.value end)
+      assert "<https://www.artsy.net/artist/old|old>" in attachments
+      assert "<https://www.artsy.net/artist/new|RICHARD BOSMAN>" in attachments
+    end
+
+    test "from one artist to no artist (unmatched)" do
+      event = Fixtures.auction_results_artist_change_event("old", nil)
+      slack_view = AuctionResultsSlackView.render(nil, event)
+      assert slack_view.text == "Artist match updated for The Fall by Richard Bosman, #126 at Christie's: Contemporary Edition (2022-03-09) (#751294)"
+      attachments = slack_view.attachments |> Enum.flat_map(fn a -> a.fields end) |> Enum.map(fn field -> field.value end)
+      assert "<https://www.artsy.net/artist/old|old>" in attachments
+      assert "<https://www.artsy.net/artist/new|RICHARD BOSMAN>" not in attachments
+    end
+
+    test "from no artist (unmatched) to an artist" do
+      event = Fixtures.auction_results_artist_change_event(nil)
+      slack_view = AuctionResultsSlackView.render(nil, event)
+      assert slack_view.text == "Artist match updated for The Fall by Richard Bosman, #126 at Christie's: Contemporary Edition (2022-03-09) (#751294)"
+      attachments = slack_view.attachments |> Enum.flat_map(fn a -> a.fields end) |> Enum.map(fn field -> field.value end)
+      assert "<https://www.artsy.net/artist/old|old>" not in attachments
+      assert "<https://www.artsy.net/artist/new|RICHARD BOSMAN>" in attachments
+    end
+  end
+end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -187,6 +187,59 @@ defmodule Apr.Fixtures do
     }
   end
 
+  def auction_results_artist_change_event(old_artist_id \\ "old", artist_id \\ "new")
+
+  def auction_results_artist_change_event(old_artist_id, nil) do
+    %{
+      "verb" => "artist_change",
+      "subject" => nil,
+      "object" => %{
+        "id" => "751294",
+        "root_type" => "Lot",
+        "display" => "The Fall by Richard Bosman, #126 at Christie's: Contemporary Edition (2022-03-09)"
+      },
+      "properties" => %{
+        "old_artist_id" => old_artist_id,
+        "artist_id" => nil,
+        "match" => nil,
+        "maker_text" => "Richard Bosman"
+      }
+    }
+  end
+
+  def auction_results_artist_change_event(old_artist_id, artist_id) do
+    %{
+      "verb" => "artist_change",
+      "subject" => nil,
+      "object" => %{
+        "id" => "751294",
+        "root_type" => "Lot",
+        "display" => "The Fall by Richard Bosman, #126 at Christie's: Contemporary Edition (2022-03-09)"
+      },
+      "properties" => %{
+        "old_artist_id" => old_artist_id,
+        "artist_id" => artist_id,
+        "match" => %{
+          "_index" => "artists_staging",
+          "_type" => "_doc",
+          "_id" => "5c19768dddcc7a07c5c34572",
+          "_score" => 224.4639,
+          "_source" => %{
+            "alternate_names" => nil,
+            "nationality" => [
+              "American"
+            ],
+            "follow_count" => 18,
+            "name" => "RICHARD BOSMAN",
+            "name_exact" => "richard bosman",
+            "birth_year" => "1944-01-01"
+          }
+        },
+        "maker_text" => "Richard Bosman"
+      }
+    }
+  end
+
   def partner_update_event(verb \\ "updated", changes \\ []) do
     %{
       "verb" => verb,


### PR DESCRIPTION
Related to artist-matching quality improvements ([DO-505](https://artsyproduct.atlassian.net/browse/DO-505)), we'd like to be notified of _changes_ to auction results' matched artists on a more ongoing basis. Currently, changes are deduced from repeated SQL queries over consecutive periods.

This adds `auction_results` as a supported topic for slack subscriptions, and a view handler for the `artist_change` event specifically.

Bonus (in an isolated commit and file): I updated the setup script to handle `zsh` and modern homebrew.