### PR TITLE
fix: handle empty artist references better

### DIFF
--- a/lib/apr/views/helpers/view_helper.ex
+++ b/lib/apr/views/helpers/view_helper.ex
@@ -24,6 +24,8 @@ defmodule Apr.Views.Helper do
     "https://www.artsy.net/artist/#{artist_id}"
   end
 
+  def formatted_artist_link(nil), do: "(none)"
+
   def formatted_artist_link(artist_id) do
     "<#{artist_link(artist_id)}|#{artist_id}>"
   end


### PR DESCRIPTION
Seeing a lot of this after https://github.com/artsy/aprd/pull/381:

```
New artist:
https://www.artsy.net/artist/
```

Let's render `(none)` instead of a malformed artist link.