### PR TITLE
fix: renovate assignee

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "extends": ["@artsy:app"],
-  "assignees": ["joeyAghion"],
+  "assignees": ["jpotts244"],
   "ignoreDeps": ["phoenix", "phoenix_html", "phoenix_live_view"]
 }


### PR DESCRIPTION
Why should your fun be limited to dependabot updates?