### PR TITLE
feat(TX-209): send merchant deactivated notification

### DIFF
--- a/lib/apr/views/seller_slack_view.ex
+++ b/lib/apr/views/seller_slack_view.ex
@@ -9,6 +9,9 @@ defmodule Apr.Views.SellerSlackView do
       routing_key == "merchantaccount.external_account_restricted_soon" ->
         external_account_restricted_soon_message(event, partner_data)
 
+      routing_key == "merchantaccount.deactivated" ->
+        external_account_deactivated_message(event, partner_data)
+
       routing_key =~ "merchantaccount" ->
         merchant_account_message(event, partner_data)
 
@@ -36,6 +39,24 @@ defmodule Apr.Views.SellerSlackView do
               value: Enum.join(event["properties"]["stripe_requirements"]["requirements"], ", "),
               short: true
             },
+            %{
+              title: "Stripe account ID",
+              value: formatted_stripe_account_link(event["properties"]["external_id"]),
+              short: true
+            }
+          ]
+        }
+      ],
+      unfurl_links: true
+    }
+  end
+
+  defp external_account_deactivated_message(event, partner_data) do
+    %{
+      text: ":warning: Stripe account of #{partner_data["name"]} was disconnected from Stripe",
+      attachments: [
+        %{
+          fields: [
             %{
               title: "Stripe account ID",
               value: formatted_stripe_account_link(event["properties"]["external_id"]),

--- a/test/apr/seller_slack_view_test.exs
+++ b/test/apr/seller_slack_view_test.exs
@@ -44,9 +44,9 @@ defmodule Apr.Views.SellerSlackViewTest do
       }
     end
 
-    test "merchant_account event with external_deactivated routing_key" do
-      event = Apr.Fixtures.seller_event("external_deactivated")
-      slack_view = SellerSlackView.render(nil, event, "merchantaccount.external_deactivated")
+    test "merchant_account event with deactivated routing_key" do
+      event = Apr.Fixtures.seller_event("deactivated")
+      slack_view = SellerSlackView.render(nil, event, "merchantaccount.deactivated")
 
       assert slack_view == %{
         attachments: [

--- a/test/apr/seller_slack_view_test.exs
+++ b/test/apr/seller_slack_view_test.exs
@@ -44,6 +44,27 @@ defmodule Apr.Views.SellerSlackViewTest do
       }
     end
 
+    test "merchant_account event with external_deactivated routing_key" do
+      event = Apr.Fixtures.seller_event("external_deactivated")
+      slack_view = SellerSlackView.render(nil, event, "merchantaccount.external_deactivated")
+
+      assert slack_view == %{
+        attachments: [
+          %{
+            fields: [
+              %{
+                short: true,
+                title: "Stripe account ID",
+                value: "<https://dashboard.stripe.com/connect/accounts/stripe_account_id/activity|stripe_account_id>"
+              }
+            ]
+          }
+        ],
+        text: ":warning: Stripe account of Mocked Partner2 was disconnected from Stripe",
+        unfurl_links: true
+      }
+    end
+
     test "seller event with merchantaccount routing_key" do
       event = Apr.Fixtures.seller_event()
       slack_view = SellerSlackView.render(nil, event, "merchantaccount")


### PR DESCRIPTION
relates to https://github.com/artsy/gravity/pull/16320

Listen to `merchantaccount.deactivated` and send a slack notification that the merchant was deactivated.