### PR TITLE
fix: path to asdf script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -32,7 +32,7 @@ fi
 echo "Setup asdf, if required..."
 if (! grep 'asdf.sh' $PROFILE)
 then
-  echo -e "\n. $(brew --prefix asdf)/asdf.sh" >> $PROFILE
+  echo -e "\n. $(brew --prefix asdf)/libexec/asdf.sh" >> $PROFILE
   if [[ "$SHELL" = *"bash"* ]]; then
     source $PROFILE
   elif [[ "$SHELL" = *"zsh"* ]]; then


### PR DESCRIPTION
I have been getting stuck at the "Prepare mix..." step of the setup script for some time now, and was able to get past it after realizing that the asdf.sh script is not located in the asdf root directory, but in the libexec subdirectory. (See the section titled **Install asdf** [here](https://asdf-vm.com/guide/getting-started.html).)

This PR updates the setup script to reflect the expected location of that script from the asdf documentation.