### PR TITLE
fix: install autoconf 2.69 by default

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -50,17 +50,11 @@ asdf plugin update erlang
 asdf plugin update elixir
 
 echo "asdf install erlang..."
-# On Mojave (and possibly other Mac versions), you might encounter:
-# configure: error: cannot find required auxiliary files: install-sh config.guess config.sub
-# Installing autoconf 2.69 solves it.
-version=$(sw_vers -productVersion | cut -f1,2 -d'.')
-# if Mojave
-if [[ $version == '10.14.6' ]]
-then
-  brew install autoconf@2.69 && \
-  brew link --overwrite autoconf@2.69 && \
-  autoconf -V
-fi
+
+brew install autoconf@2.69 && \
+brew link --overwrite autoconf@2.69 && \
+autoconf -V
+
 asdf install erlang 23.1.1
 asdf local erlang 23.1.1
 


### PR DESCRIPTION
This PR updates the APRd setup script to install autoconf 2.69 by default. It currently only does it for a specific version of macOS (10.14.6), but I have needed to perform this step manually in subsequent versions as well.

An alternative approach would be to use `is-at-least`, but I think that is only available for Zsh:

```sh
is-at-least "10.14.6" "$(sw_vers -productVersion)"
```

