### PR TITLE
feat: display a custom Slack view for Stripe account inactive error events

### DIFF
--- a/lib/apr/views/commerce/commerce_error_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_error_slack_view.ex
@@ -10,6 +10,7 @@ defmodule Apr.Views.CommerceErrorSlackView do
   def render(_, event, _routing_key) do
     case event["properties"]["code"] do
       "tax_mismatch" -> tax_mismatch_message(event)
+      "stripe_account_inactive" -> stripe_account_inactive_message(event)
       _ -> default_message(event)
     end
   end
@@ -89,6 +90,25 @@ defmodule Apr.Views.CommerceErrorSlackView do
         }
       ],
       unfurl_links: true
+    }
+  end
+
+  defp stripe_account_inactive_message(event) do
+    order_id = event["properties"]["data"]["order_id"]
+
+    %{
+      text: "An order is blocked because the seller's stripe account is inactive.",
+      attachments: [
+        %{
+          fields: [
+            %{
+              title: "Order ID",
+              value: "<#{exchange_admin_link(order_id)}|#{order_id}>",
+              short: true
+            }
+          ]
+        }
+      ]
     }
   end
 end

--- a/test/apr/views/commerce/commerce_error_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_error_slack_view_test.exs
@@ -29,4 +29,12 @@ defmodule Apr.Views.CommerceErrorSlackViewTest do
 
     assert slack_view[:unfurl_links] == true
   end
+
+  test "stripe account inactive error slack view" do
+    event = Apr.Fixtures.stripe_account_inactive_error_event()
+    slack_view = CommerceErrorSlackView.render(%Subscription{}, event, "commerce.stripe_account_inactive")
+
+    assert slack_view.text == "An order is blocked because the seller's stripe account is inactive."
+    assert Enum.map(List.first(slack_view.attachments).fields, fn field -> field.title end) == ["Order ID"]
+  end
 end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -93,6 +93,22 @@ defmodule Apr.Fixtures do
     }
   end
 
+  def stripe_account_inactive_error_event() do
+    %{
+      "object" => %{
+        "id" => "FailedTransactionError",
+        "display" => "FailedTransactionError"
+      },
+      "properties" => %{
+        "type" => "processing",
+        "code" => "stripe_account_inactive",
+        "data" => %{
+          "order_id" => "order1"
+        }
+      }
+    }
+  end
+
   def commerce_offer_order(verb \\ "submitted", properties \\ %{}),
     do: commerce_order_event(verb, properties |> Map.merge(%{"mode" => "offer"}))
 


### PR DESCRIPTION
This PR adds a custom Slack view for `commerce.errors.processing.stripe_account_inactive` events. Before creating a custom Slack view, the alert we received when subscribing to that event looked liked this:

<img width="584" alt="Screenshot 2023-07-06 at 2 40 45 PM" src="https://github.com/artsy/aprd/assets/44589599/e2b783c6-3ff8-4021-81fc-08e7a1bdde24">

We would like to raise this alert in an admin-facing channel so that they can reach out to the partner's account executive and resolve the Stripe issue. Therefore, we have simplified the alert message and added a link to the order in Exchange to begin that process.