### PR TITLE
Notify disputes for non-credit card orders

### DIFF
--- a/lib/apr/views/commerce_transaction_created_slack_view.ex
+++ b/lib/apr/views/commerce_transaction_created_slack_view.ex
@@ -2,8 +2,8 @@ defmodule Apr.Views.CommerceTransactionCreatedSlackView do
   import Apr.Views.Helper
 
   def render(subscription, event, _routing_key) do
-    case {subscription.theme, event["properties"]["external_type"], event["verb"], event["properties"]["transaction_type"], event["properties"]["order"]["payment_method"]} do
-      {"dispute", "payment_intent", "created", "dispute", "us_bank_account"} ->
+    case {subscription.theme, event["verb"], event["properties"]} do
+      {"dispute", "created", %{"external_type" => "payment_intent", "transaction_type" => "dispute", "order" => %{"payment_method" => payment_method}}} when payment_method != "credit card" ->
         generate_slack_message(event)
       _ -> nil
     end

--- a/test/apr/views/commerce_transaction_created_slack_view_test.exs
+++ b/test/apr/views/commerce_transaction_created_slack_view_test.exs
@@ -7,12 +7,12 @@ defmodule Apr.Views.CommerceTransactionCreatedSlackViewTest do
   @subscription %Subscription{theme: "dispute"}
 
   describe "render/2" do
-    test "disputed payment" do
+    test "does not generate message for credit card disputes" do
       event = Fixtures.commerce_transaction_event(
         %{
           "id" => "order123",
           "seller_id" => "partner1",
-          "payment_method" => "us_bank_account",
+          "payment_method" => "credit card",
         },
         %{
           "verb" => "created",
@@ -22,32 +22,52 @@ defmodule Apr.Views.CommerceTransactionCreatedSlackViewTest do
         }
       )
       slack_view = CommerceTransactionCreatedSlackView.render(@subscription, event, "dispute")
+      assert is_nil(slack_view)
+    end
 
-      assert slack_view == %{
-        attachments: [
+    for payment_method <- ["us_bank_account", "sepa_debit"] do
+      test "generates message for #{payment_method} disputes" do
+        event = Fixtures.commerce_transaction_event(
           %{
-            fields: [
-              %{
-                short: true,
-                title: "Order ID",
-                value: "<https://exchange.artsy.net/admin/orders/order123|order123>"
-              },
-              %{
-                short: true,
-                title: "Seller ID",
-                value: "<https://admin-partners.artsy.net/partners/partner1|partner1>"
-              },
-              %{
-                short: true,
-                title: "Stripe payment ID",
-                value: "<https://dashboard.stripe.com/payments/pi_123|pi_123>"
-              }
-            ]
+            "id" => "order123",
+            "seller_id" => "partner1",
+            "payment_method" => unquote(payment_method),
+          },
+          %{
+            "verb" => "created",
+            "transaction_type" => "dispute",
+            "external_id" => "pi_123",
+            "external_type" => "payment_intent",
           }
-        ],
-        text: ":alert: Dispute, do not refund this order on Stripe",
-        unfurl_links: true
-      }
+        )
+        slack_view = CommerceTransactionCreatedSlackView.render(@subscription, event, "dispute")
+
+        assert slack_view == %{
+          attachments: [
+            %{
+              fields: [
+                %{
+                  short: true,
+                  title: "Order ID",
+                  value: "<https://exchange.artsy.net/admin/orders/order123|order123>"
+                },
+                %{
+                  short: true,
+                  title: "Seller ID",
+                  value: "<https://admin-partners.artsy.net/partners/partner1|partner1>"
+                },
+                %{
+                  short: true,
+                  title: "Stripe payment ID",
+                  value: "<https://dashboard.stripe.com/payments/pi_123|pi_123>"
+                }
+              ]
+            }
+          ],
+          text: ":alert: Dispute, do not refund this order on Stripe",
+          unfurl_links: true
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/EMI-1275

We currently notify disputes for ACH orders. We want to do the same for SEPA and potentially future payment methods. This updates the logic to trigger dispute notification for all payment methods except for credit cards.