### PR TITLE
fix: Allow exchange URL to be pulled from environment vars

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -38,7 +38,7 @@ config :sentry,
   }
 
 config :apr, :metaphysics, url: System.get_env("METAPHYSICS_URL")
-config :apr, :exchange, url: System.get_env("EXCHANGE_URL")
+config :apr, :exchange, url: System.get_env("EXCHANGE_URL") || "https://exchange-staging.artsy.net"
 config :apr, :artsy_admin, url: System.get_env("ARTSY_ADMIN_URL")
 
 # Configures Elixir's Logger

--- a/lib/apr/views/helpers/view_helper.ex
+++ b/lib/apr/views/helpers/view_helper.ex
@@ -1,5 +1,5 @@
 defmodule Apr.Views.Helper do
-  @exchange_url "https://exchange.artsy.net"
+  @exchange_url Application.get_env(:apr, :exchange)[:url]
   @stripe_search_url "https://dashboard.stripe.com/search"
   @gravity_api Application.get_env(:apr, :gravity_api)
 

--- a/test/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view_test.exs
@@ -14,7 +14,7 @@ defmodule Apr.Views.CommerceShippingQuoteDisqualifiedSlackViewTest do
               %{
               short: true,
               title: "Shipping quotes cannot be generated for Order",
-              value: "<https://exchange.artsy.net/admin/orders/order-id-hello|order-id-hello>"
+              value: "<https://exchange-staging.artsy.net/admin/orders/order-id-hello|order-id-hello>"
               }
           ]
           }

--- a/test/apr/views/commerce_transaction_created_slack_view_test.exs
+++ b/test/apr/views/commerce_transaction_created_slack_view_test.exs
@@ -30,7 +30,7 @@ defmodule Apr.Views.CommerceTransactionCreatedSlackViewTest do
               %{
                 short: true,
                 title: "Order ID",
-                value: "<https://exchange.artsy.net/admin/orders/order123|order123>"
+                value: "<https://exchange-staging.artsy.net/admin/orders/order123|order123>"
               },
               %{
                 short: true,


### PR DESCRIPTION
Staging notifications were linking to exchange production
Allow these URLs to be configurable based on environment - Any objections?