### PR TITLE
chore: Add additional link to shipping disqualification alert to arta dashboard

### DIFF
--- a/lib/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view.ex
@@ -8,8 +8,13 @@ defmodule Apr.Views.CommerceShippingQuoteDisqualifiedSlackView do
         %{
           fields: [
             %{
-              title: "Shipping quotes cannot be generated for Order",
+              title: "Exchange Admin Order",
               value: formatted_exchange_admin_link(event["properties"]["order"]["id"]),
+              short: true
+            },
+            %{
+              title: "ARTA Dashboard link for Order",
+              value: formatted_arta_dashboard_link(event["object"]["external_id"]),
               short: true
             }
           ]
@@ -21,5 +26,9 @@ defmodule Apr.Views.CommerceShippingQuoteDisqualifiedSlackView do
 
   defp formatted_exchange_admin_link(order_id) do
     "<#{exchange_admin_link(order_id)}|#{order_id}>"
+  end
+
+  defp formatted_arta_dashboard_link(external_id) do
+    "<https://dashboard.arta.io/org/ARTSY/requests/#{external_id}|#{external_id}>"
   end
 end

--- a/test/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view_test.exs
@@ -10,13 +10,18 @@ defmodule Apr.Views.CommerceShippingQuoteDisqualifiedSlackViewTest do
     assert slack_view == %{
       attachments: [
           %{
-          fields: [
+            fields: [
               %{
-              short: true,
-              title: "Shipping quotes cannot be generated for Order",
-              value: "<https://exchange.artsy.net/admin/orders/order-id-hello|order-id-hello>"
+                title: "Exchange Admin Order",
+                value: "<https://exchange.artsy.net/admin/orders/order-id-hello|order-id-hello>",
+                short: true
+              },
+              %{
+                title: "ARTA Dashboard link for Order",
+                value: "<https://dashboard.arta.io/org/ARTSY/requests/123|123>",
+                short: true
               }
-          ]
+            ]
           }
       ],
       text: ":warning: :package: Shipping quotes cannot be generated for Artsy Shipping Order #{event["properties"]["order"]["id"]}",


### PR DESCRIPTION
Feedback from MSO while testing

Lets surface a link to Arta's side of things for shipping disqualifications