### PR TITLE
fix: Allow exchange url to be configurable

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -38,7 +38,7 @@ config :sentry,
   }
 
 config :apr, :metaphysics, url: System.get_env("METAPHYSICS_URL")
-config :apr, :exchange, url: System.get_env("EXCHANGE_URL")
+config :apr, :exchange, url: System.get_env("EXCHANGE_URL", "https://exchange-staging.artsy.net")
 config :apr, :artsy_admin, url: System.get_env("ARTSY_ADMIN_URL")
 
 # Configures Elixir's Logger

--- a/lib/apr/views/helpers/view_helper.ex
+++ b/lib/apr/views/helpers/view_helper.ex
@@ -1,5 +1,5 @@
 defmodule Apr.Views.Helper do
-  @exchange_url "https://exchange.artsy.net"
+  @exchange_url Application.get_env(:apr, :exchange)[:url]
   @stripe_search_url "https://dashboard.stripe.com/search"
   @gravity_api Application.get_env(:apr, :gravity_api)
 

--- a/test/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view_test.exs
@@ -13,7 +13,7 @@ defmodule Apr.Views.CommerceShippingQuoteDisqualifiedSlackViewTest do
             fields: [
               %{
                 title: "Exchange Admin Order",
-                value: "<https://exchange-staging.artsy.net/admin/orders/order-id-hello|order-id-hello>"
+                value: "<https://exchange-staging.artsy.net/admin/orders/order-id-hello|order-id-hello>",
                 short: true
               },
               %{

--- a/test/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view_test.exs
@@ -13,7 +13,7 @@ defmodule Apr.Views.CommerceShippingQuoteDisqualifiedSlackViewTest do
             fields: [
               %{
                 title: "Exchange Admin Order",
-                value: "<https://exchange.artsy.net/admin/orders/order-id-hello|order-id-hello>",
+                value: "<https://exchange-staging.artsy.net/admin/orders/order-id-hello|order-id-hello>"
                 short: true
               },
               %{

--- a/test/apr/views/commerce_transaction_created_slack_view_test.exs
+++ b/test/apr/views/commerce_transaction_created_slack_view_test.exs
@@ -49,7 +49,7 @@ defmodule Apr.Views.CommerceTransactionCreatedSlackViewTest do
                 %{
                   short: true,
                   title: "Order ID",
-                  value: "<https://exchange.artsy.net/admin/orders/order123|order123>"
+                  value: "<https://exchange-staging.artsy.net/admin/orders/order123|order123>"
                 },
                 %{
                   short: true,


### PR DESCRIPTION
[My first pass of doing this was not successful](https://github.com/artsy/aprd/pull/435/files#diff-4648011d067e5ac08390c9bde0abb307cd920d3fcad02e43566631d3766090a2R2). This change will use the `System.get_env()` with a fallback instead of a double pipe operation ([.get_env Elixir docs](https://hexdocs.pm/elixir/1.12/System.html#get_env/2))
Discussion [here](https://artsy.slack.com/archives/CP9P4KR35/p1689002696472849)


The `||` operator in Elixir has a slightly different behavior than what I was expecting. 
See the diff in Ruby vs Elixir 😓 

<img width="650" alt="Screen Shot 2023-07-10 at 5 56 51 PM" src="https://github.com/artsy/aprd/assets/12748344/b09519b8-8b4d-4661-8afc-db9b18db04c7">


---




