### PR TITLE
Fix for external id pointer

### DIFF
--- a/lib/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view.ex
@@ -14,7 +14,7 @@ defmodule Apr.Views.CommerceShippingQuoteDisqualifiedSlackView do
             },
             %{
               title: "ARTA Dashboard link for Order",
-              value: formatted_arta_dashboard_link(event["object"]["external_id"]),
+              value: formatted_arta_dashboard_link(event["object"]["id"]),
               short: true
             }
           ]

--- a/test/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view_test.exs
@@ -18,7 +18,7 @@ defmodule Apr.Views.CommerceShippingQuoteDisqualifiedSlackViewTest do
               },
               %{
                 title: "ARTA Dashboard link for Order",
-                value: "<https://dashboard.arta.io/org/ARTSY/requests/123|123>",
+                value: "<https://dashboard.arta.io/org/ARTSY/requests/shipping-quote-request-id|shipping-quote-request-id>",
                 short: true
               }
             ]

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -208,7 +208,7 @@ defmodule Apr.Fixtures do
     %{  
       "object" => %{
         "id" => "shipping-quote-request-id",
-        "external_id" => "123"
+        "external_id" => "artsy-order-code"
       },
       "subject" => %{
         "id" => "user1",


### PR DESCRIPTION
Fix for external id pointer which was coming back as `nil` on staging

Looking at the where this event gets triggered in exchange, I just noticed that we are passing in raw data from arta [here](https://github.com/artsy/exchange/blob/main/app/services/arta/shipping_service.rb#L16) and not querying the data on our side. (In fact there is nothing persisted yet until [this](https://github.com/artsy/exchange/blob/main/app/services/arta/shipping_service.rb#L18-L31) line below the event call)


So all this to say is that in the event we are sending in a ShippingQuoteRequest-ish object (it is just the response data from ARTA) so the terminology is different that our database. This is arta's terminology in the event object `id` in this case is ARTA’s `id` and `external_id` is our `order.code`