### PR TITLE
fix: pull id from event properties json

### DIFF
--- a/lib/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view.ex
@@ -14,7 +14,7 @@ defmodule Apr.Views.CommerceShippingQuoteDisqualifiedSlackView do
             },
             %{
               title: "ARTA Dashboard link for Order",
-              value: formatted_arta_dashboard_link(event["object"]["id"]),
+              value: formatted_arta_dashboard_link(event["properties"]["id"]),
               short: true
             }
           ]

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -215,6 +215,7 @@ defmodule Apr.Fixtures do
       },
       "verb" => verb,
       "properties" => %{
+        "id" => "shipping-quote-request-id",
         "order" => %{
           "id" => "order-id-hello"
         },


### PR DESCRIPTION
Gah! Very sorry, I think I am trying to pull this value from the wrong object and I was reading the [exchange code](https://github.com/artsy/exchange/blob/main/app/events/shipping_quote_request_event.rb#L23-L27
) incorrectly
This is hard to test locally