### PR TITLE
chore(AMBER-2): Set Shipping Quote Request External ID

### DIFF
--- a/lib/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view.ex
@@ -14,7 +14,7 @@ defmodule Apr.Views.CommerceShippingQuoteDisqualifiedSlackView do
             },
             %{
               title: "ARTA Dashboard link for Order",
-              value: formatted_arta_dashboard_link(event["properties"]["id"]),
+              value: formatted_arta_dashboard_link(event["properties"]["external_id"]),
               short: true
             }
           ]

--- a/test/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view_test.exs
@@ -18,7 +18,7 @@ defmodule Apr.Views.CommerceShippingQuoteDisqualifiedSlackViewTest do
               },
               %{
                 title: "ARTA Dashboard link for Order",
-                value: "<https://dashboard.arta.io/org/ARTSY/requests/shipping-quote-request-id|shipping-quote-request-id>",
+                value: "<https://dashboard.arta.io/org/ARTSY/requests/arta-request-id|arta-request-id>",
                 short: true
               }
             ]

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -207,8 +207,7 @@ defmodule Apr.Fixtures do
   def shipping_quote_disqualified_event(verb \\ "disqualified", properties \\ %{}) do
     %{  
       "object" => %{
-        "id" => "shipping-quote-request-id",
-        "external_id" => "artsy-order-code"
+        "id" => "shipping-quote-request-id"
       },
       "subject" => %{
         "id" => "user1",
@@ -216,6 +215,7 @@ defmodule Apr.Fixtures do
       "verb" => verb,
       "properties" => %{
         "id" => "shipping-quote-request-id",
+        "external_id" => "arta-request-id",
         "order" => %{
           "id" => "order-id-hello"
         },


### PR DESCRIPTION
[AMBER-2]

We want shipping quote request notification to contain a link to the shipping request in ARTA dashboard. In order to do this, we need to set `external_id` according to the data exposed by the event (see: https://github.com/artsy/exchange/pull/1725)

For more on this, see:
https://artsy.slack.com/archives/C05F8TNKGAV/p1689065530929119?thread_ts=1688995108.405869&cid=C05F8TNKGAV

[AMBER-2]: https://artsyproduct.atlassian.net/browse/AMBER-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ