### PR TITLE
Revert "fix: Allow exchange url to be configurable"

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -38,7 +38,7 @@ config :sentry,
   }
 
 config :apr, :metaphysics, url: System.get_env("METAPHYSICS_URL")
-config :apr, :exchange, url: System.get_env("EXCHANGE_URL", "https://exchange-staging.artsy.net")
+config :apr, :exchange, url: System.get_env("EXCHANGE_URL")
 config :apr, :artsy_admin, url: System.get_env("ARTSY_ADMIN_URL")
 
 # Configures Elixir's Logger

--- a/lib/apr/views/helpers/view_helper.ex
+++ b/lib/apr/views/helpers/view_helper.ex
@@ -1,5 +1,5 @@
 defmodule Apr.Views.Helper do
-  @exchange_url Application.get_env(:apr, :exchange)[:url]
+  @exchange_url "https://exchange.artsy.net"
   @stripe_search_url "https://dashboard.stripe.com/search"
   @gravity_api Application.get_env(:apr, :gravity_api)
 

--- a/test/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view_test.exs
@@ -13,7 +13,7 @@ defmodule Apr.Views.CommerceShippingQuoteDisqualifiedSlackViewTest do
             fields: [
               %{
                 title: "Exchange Admin Order",
-                value: "<https://exchange-staging.artsy.net/admin/orders/order-id-hello|order-id-hello>",
+                value: "<https://exchange.artsy.net/admin/orders/order-id-hello|order-id-hello>",
                 short: true
               },
               %{

--- a/test/apr/views/commerce_transaction_created_slack_view_test.exs
+++ b/test/apr/views/commerce_transaction_created_slack_view_test.exs
@@ -49,7 +49,7 @@ defmodule Apr.Views.CommerceTransactionCreatedSlackViewTest do
                 %{
                   short: true,
                   title: "Order ID",
-                  value: "<https://exchange-staging.artsy.net/admin/orders/order123|order123>"
+                  value: "<https://exchange.artsy.net/admin/orders/order123|order123>"
                 },
                 %{
                   short: true,


### PR DESCRIPTION
Reverts artsy/aprd#440

I'm reverting this PR for now, because after it was merged/deployed (6 hours ago) all of the notifications on #order and #bnmo-fraud are pointing to staging regardless of the environment (see [report here](https://artsy.slack.com/archives/CDKJ10VEH/p1689092218221879?thread_ts=1689001760.443059&cid=CDKJ10VEH)).

Not clear to me why this happens.
If I open the console in the production environment and try to fetch the value of Exchange URL, I'm able to retrieve the expected value (production):

```
hokusai production run "iex -S mix" --tty

iex(1)> Application.get_env(:apr, :exchange)
[url: "https://exchange.artsy.net"]
```

But for some reason, notifications are still being triggered pointing to the wrong URL.

I'm reverting this for now until we can understand why this is happening.