### PR TITLE
chore: Use money helper instead of hardcoded calculation

### DIFF
--- a/lib/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view.ex
@@ -19,9 +19,9 @@ defmodule Apr.Views.CommerceShippingQuoteDisqualifiedSlackView do
             },
             %{
               title: "Artwork Listed Price",
-              value: formatted_list_price(
-                event["properties"]["order"]["currency_code"],
-                event["properties"]["order"]["total_list_price_cents"]
+              value: format_price(
+                String.to_integer(event["properties"]["order"]["total_list_price_cents"]),
+                event["properties"]["order"]["currency_code"]
               ),
               short: true
             },
@@ -38,11 +38,5 @@ defmodule Apr.Views.CommerceShippingQuoteDisqualifiedSlackView do
 
   defp formatted_arta_dashboard_link(external_id) do
     "<https://dashboard.arta.io/org/ARTSY/requests/#{external_id}|#{external_id}>"
-  end
-
-  defp formatted_list_price(currency_code, list_price_cents) do
-    price = Decimal.new(list_price_cents)
-
-    "#{currency_code} #{Decimal.div(price, 100)}"
   end
 end

--- a/test/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view_test.exs
@@ -23,7 +23,7 @@ defmodule Apr.Views.CommerceShippingQuoteDisqualifiedSlackViewTest do
               },
               %{
                 title: "Artwork Listed Price",
-                value: "USD 110000",
+                value: "$110,000.00",
                 short: true
               }
             ]


### PR DESCRIPTION
## Use the money formatter helper for the listed price
We already have a helper in place. Therefore, we shouldn't be hardcoding money calculations in other places.

As per this comment:
https://github.com/artsy/aprd/pull/446#discussion_r1260042725