### PR TITLE
Fix: Treat total_list_price_cents as Integer and not a String type 

### DIFF
--- a/lib/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view.ex
@@ -19,10 +19,7 @@ defmodule Apr.Views.CommerceShippingQuoteDisqualifiedSlackView do
             },
             %{
               title: "Artwork Listed Price",
-              value: format_price(
-                String.to_integer(event["properties"]["order"]["total_list_price_cents"]),
-                event["properties"]["order"]["currency_code"]
-              ),
+              value: format_artwork_listed_price(event),
               short: true
             },
           ]
@@ -38,5 +35,12 @@ defmodule Apr.Views.CommerceShippingQuoteDisqualifiedSlackView do
 
   defp formatted_arta_dashboard_link(external_id) do
     "<https://dashboard.arta.io/org/ARTSY/requests/#{external_id}|#{external_id}>"
+  end
+
+  defp format_artwork_listed_price(event) do
+    case event["properties"]["order"]["total_list_price_cents"] do
+      nil -> "N/A" # Handle the case of nil
+      cents -> format_price(cents, event["properties"]["order"]["currency_code"])
+    end
   end
 end

--- a/test/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_shipping_quote_disqualified_slack_view_test.exs
@@ -22,9 +22,40 @@ defmodule Apr.Views.CommerceShippingQuoteDisqualifiedSlackViewTest do
                 short: true
               },
               %{
-                title: "Artwork Listed Price",
-                value: "$110,000.00",
+                short: true, 
+                title: "Artwork Listed Price", 
+                value: "$110,000.00"
+              }
+            ]
+          }
+      ],
+      text: ":warning: :package: Shipping quotes cannot be generated for Artsy Shipping Order #{event["properties"]["order"]["id"]}",
+      unfurl_links: true
+    }
+  end
+
+  test "shipping quote disqualifed event when list price is not present" do
+    event = Apr.Fixtures.shipping_quote_disqualified_missing_data_event("disqualified")
+    slack_view = CommerceShippingQuoteDisqualifiedSlackView.render(nil, event, "disqualified")
+        
+    assert slack_view == %{
+      attachments: [
+          %{
+            fields: [
+              %{
+                title: "Exchange Admin Order",
+                value: "<https://exchange.artsy.net/admin/orders/order-id-hello|order-id-hello>",
                 short: true
+              },
+              %{
+                title: "ARTA Dashboard link for Order",
+                value: "<https://dashboard.arta.io/org/ARTSY/requests/arta-request-id|arta-request-id>",
+                short: true
+              },
+              %{
+                short: true, 
+                title: "Artwork Listed Price", 
+                value: "N/A"
               }
             ]
           }

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -218,7 +218,29 @@ defmodule Apr.Fixtures do
         "external_id" => "arta-request-id",
         "order" => %{
           "id" => "order-id-hello",
-          "total_list_price_cents" => "11000000",
+          "total_list_price_cents" => 11000000,
+          "currency_code" => "USD"
+        },
+      }
+      |> Map.merge(properties)
+    }
+  end
+
+  def shipping_quote_disqualified_missing_data_event(verb \\ "disqualified", properties \\ %{}) do
+    %{  
+      "object" => %{
+        "id" => "shipping-quote-request-id"
+      },
+      "subject" => %{
+        "id" => "user1",
+      },
+      "verb" => verb,
+      "properties" => %{
+        "id" => "shipping-quote-request-id",
+        "external_id" => "arta-request-id",
+        "order" => %{
+          "id" => "order-id-hello",
+          "total_list_price_cents" => nil,
           "currency_code" => "USD"
         },
       }


### PR DESCRIPTION
Fix for a type issue that was causing our `Shipping quotes cannot be generated for Artsy Shipping Order ` Slack notifications to not get sent 


An Argument error was throwing an exception in the logs from this line of code:
```
String.to_integer(event["properties"]["order"]["total_list_price_cents"]),
```


This is because the incoming `total_list_price_cents` data is of type **integer** and previously we were treating it as a string.
Adds additional handling in case of `nil`s