### PR TITLE
feat(EMI-1325): update stripe_account_inactive_message fields

### DIFF
--- a/lib/apr/views/commerce/commerce_error_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_error_slack_view.ex
@@ -102,8 +102,18 @@ defmodule Apr.Views.CommerceErrorSlackView do
         %{
           fields: [
             %{
-              title: "Order ID",
+              title: "Order: #{order_id}",
               value: "<#{exchange_admin_link(order_id)}|#{order_id}>",
+              short: true
+            },
+            %{
+              title: "Partner",
+              value: event["properties"]["data"]["partner_name"],
+              short: true
+            },
+            %{
+              title: "Order Value",
+              value: event["properties"]["data"]["order_value"],
               short: true
             }
           ]

--- a/lib/apr/views/commerce/commerce_error_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_error_slack_view.ex
@@ -113,7 +113,7 @@ defmodule Apr.Views.CommerceErrorSlackView do
             },
             %{
               title: "Order Value",
-              value: event["properties"]["data"]["order_value"],
+              value: "#{event["properties"]["data"]["order_currency"]} #{event["properties"]["data"]["order_value"]}",
               short: true
             }
           ]

--- a/test/apr/views/commerce/commerce_error_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_error_slack_view_test.exs
@@ -35,6 +35,10 @@ defmodule Apr.Views.CommerceErrorSlackViewTest do
     slack_view = CommerceErrorSlackView.render(%Subscription{}, event, "commerce.stripe_account_inactive")
 
     assert slack_view.text == "An order is blocked because the seller's stripe account is inactive."
-    assert Enum.map(List.first(slack_view.attachments).fields, fn field -> field.title end) == ["Order ID"]
+    assert Enum.map(List.first(slack_view.attachments).fields, fn field -> field.title end) == [
+      "Order: order1",
+      "Partner",
+      "Order Value"
+    ]
   end
 end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -103,7 +103,9 @@ defmodule Apr.Fixtures do
         "type" => "processing",
         "code" => "stripe_account_inactive",
         "data" => %{
-          "order_id" => "order1"
+          "order_id" => "order1",
+          "partner_name" => "Partner Name",
+          "order_value" => 12345,
         }
       }
     }
@@ -205,7 +207,7 @@ defmodule Apr.Fixtures do
   end
 
   def shipping_quote_disqualified_event(verb \\ "disqualified", properties \\ %{}) do
-    %{  
+    %{
       "object" => %{
         "id" => "shipping-quote-request-id"
       },
@@ -227,7 +229,7 @@ defmodule Apr.Fixtures do
   end
 
   def shipping_quote_disqualified_missing_data_event(verb \\ "disqualified", properties \\ %{}) do
-    %{  
+    %{
       "object" => %{
         "id" => "shipping-quote-request-id"
       },

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -106,6 +106,7 @@ defmodule Apr.Fixtures do
           "order_id" => "order1",
           "partner_name" => "Partner Name",
           "order_value" => 12345,
+          "order_currency" => "USD",
         }
       }
     }


### PR DESCRIPTION
Followup for https://github.com/artsy/exchange/pull/1744

This is adding more fields to the `stripe_account_inactive_message` slack notification.

- [ ] Test on staging