### PR TITLE
fix(EMI-1325): remove order ID from title

### DIFF
--- a/lib/apr/views/commerce/commerce_error_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_error_slack_view.ex
@@ -102,7 +102,7 @@ defmodule Apr.Views.CommerceErrorSlackView do
         %{
           fields: [
             %{
-              title: "Order: #{order_id}",
+              title: "Order",
               value: "<#{exchange_admin_link(order_id)}|#{order_id}>",
               short: true
             },

--- a/test/apr/views/commerce/commerce_error_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_error_slack_view_test.exs
@@ -36,7 +36,7 @@ defmodule Apr.Views.CommerceErrorSlackViewTest do
 
     assert slack_view.text == "An order is blocked because the seller's stripe account is inactive."
     assert Enum.map(List.first(slack_view.attachments).fields, fn field -> field.title end) == [
-      "Order: order1",
+      "Order",
       "Partner",
       "Order Value"
     ]


### PR DESCRIPTION
The Order ID in both the title and link is redundant.
![image](https://github.com/artsy/aprd/assets/554507/2eb7e787-da79-49f5-9bd3-50e38964bbcd)
