### PR TITLE
feat(EMI-1325): use format_price to convert the order value

### DIFF
--- a/lib/apr/views/commerce/commerce_error_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_error_slack_view.ex
@@ -114,7 +114,10 @@ defmodule Apr.Views.CommerceErrorSlackView do
             },
             %{
               title: "Order Value",
-              value: "#{event["properties"]["data"]["order_currency"]} #{event["properties"]["data"]["order_value"]}",
+              value: format_price(
+                event["properties"]["data"]["order_value"],
+                event["properties"]["data"]["order_currency"]
+              ),
               short: true
             }
           ]

--- a/test/apr/views/commerce/commerce_error_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_error_slack_view_test.exs
@@ -44,7 +44,7 @@ defmodule Apr.Views.CommerceErrorSlackViewTest do
     assert Enum.map(List.first(slack_view.attachments).fields, fn field -> field.value end) == [
       "<https://exchange.artsy.net/admin/orders/order1|order1>",
       "<https://admin-partners.artsy.net/partners/partner1|Partner Name>",
-      "USD 12345"
+      "$123.45"
     ]
   end
 end


### PR DESCRIPTION
As [pointed](https://github.com/artsy/exchange/pull/1751/files#r1296356278) by @starsirius, we should use the existing aprd helper to convert the value.