### PR TITLE
feat(EMI-1424): Add merchant_account_external_id to Stripe Account Inactive alert

### DIFF
--- a/lib/apr/views/commerce/commerce_error_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_error_slack_view.ex
@@ -115,7 +115,7 @@ defmodule Apr.Views.CommerceErrorSlackView do
             },
             %{
               title: "Stripe Account",
-              value: "<#{stripe_account_link(merchant_account_external_id)}|#{merchant_account_external_id}>",
+              value: stripe_merchant_account_link(merchant_account_external_id),
               short: true
             },
             %{

--- a/lib/apr/views/commerce/commerce_error_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_error_slack_view.ex
@@ -95,6 +95,7 @@ defmodule Apr.Views.CommerceErrorSlackView do
 
   defp stripe_account_inactive_message(event) do
     order_id = event["properties"]["data"]["order_id"]
+    merchant_account_external_id = event["properties"]["data"]["merchant_account_external_id"]
     partner_path = "partners/#{event["properties"]["data"]["partner_id"]}"
 
     %{
@@ -110,6 +111,11 @@ defmodule Apr.Views.CommerceErrorSlackView do
             %{
               title: "Partner",
               value: "<#{admin_partners_link(partner_path)}|#{event["properties"]["data"]["partner_name"]}>",
+              short: true
+            },
+            %{
+              title: "Stripe Account",
+              value: "<#{stripe_account_link(merchant_account_external_id)}|#{merchant_account_external_id}>",
               short: true
             },
             %{

--- a/lib/apr/views/helpers/view_helper.ex
+++ b/lib/apr/views/helpers/view_helper.ex
@@ -96,6 +96,10 @@ defmodule Apr.Views.Helper do
     "#{@stripe_search_url}?#{URI.encode_query(query: query)}"
   end
 
+  def stripe_merchant_account_link(merchant_account_external_id) do
+    "https://dashboard.stripe.com/connect/accounts/#{merchant_account_external_id}"
+  end
+
   def cleanup_name(nil), do: ""
 
   def cleanup_name(full_name) do

--- a/lib/apr/views/helpers/view_helper.ex
+++ b/lib/apr/views/helpers/view_helper.ex
@@ -97,7 +97,7 @@ defmodule Apr.Views.Helper do
   end
 
   def stripe_merchant_account_link(merchant_account_external_id) do
-    if merchant_account_external_id
+    if merchant_account_external_id do
       "<https://dashboard.stripe.com/connect/accounts/#{merchant_account_external_id}|#{merchant_account_external_id}>"
     else
       "Not found"

--- a/lib/apr/views/helpers/view_helper.ex
+++ b/lib/apr/views/helpers/view_helper.ex
@@ -97,7 +97,11 @@ defmodule Apr.Views.Helper do
   end
 
   def stripe_merchant_account_link(merchant_account_external_id) do
-    "https://dashboard.stripe.com/connect/accounts/#{merchant_account_external_id}"
+    if merchant_account_external_id
+      "<https://dashboard.stripe.com/connect/accounts/#{merchant_account_external_id}|#{merchant_account_external_id}>"
+    else
+      "Not found"
+    end
   end
 
   def cleanup_name(nil), do: ""

--- a/test/apr/views/commerce/commerce_error_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_error_slack_view_test.exs
@@ -38,12 +38,14 @@ defmodule Apr.Views.CommerceErrorSlackViewTest do
     assert Enum.map(List.first(slack_view.attachments).fields, fn field -> field.title end) == [
       "Order",
       "Partner",
+      "Stripe Account",
       "Order Value"
     ]
 
     assert Enum.map(List.first(slack_view.attachments).fields, fn field -> field.value end) == [
       "<https://exchange.artsy.net/admin/orders/order1|order1>",
       "<https://admin-partners.artsy.net/partners/partner1|Partner Name>",
+      "<https://dashboard.stripe.com/connect/accounts/acct_123|acct_123>",
       "$123.45"
     ]
   end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -107,7 +107,8 @@ defmodule Apr.Fixtures do
           "order_value" => 12345,
           "order_currency" => "USD",
           "partner_id" => "partner1",
-          "partner_name" => "Partner Name"
+          "partner_name" => "Partner Name",
+          "merchant_account_external_id" => "acct_123"
         }
       }
     }


### PR DESCRIPTION
Followup from https://github.com/artsy/exchange/pull/1766

https://artsyproduct.atlassian.net/browse/EMI-1424

**Description**
Collector Services requested add a link to partner’s Stripe account to Stripe Account Inactive APRd slack notifications.

**Acceptance criteria**
Partner’s Stripe account is linked (example: https://dashboard.stripe.com/connect/accounts/acct_1IfoTpLFSgsW0WpB/activity) in the alert.