### PR TITLE
chore: fetch stripe account inactive fields

### DIFF
--- a/lib/apr/views/commerce/commerce_error_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_error_slack_view.ex
@@ -95,8 +95,10 @@ defmodule Apr.Views.CommerceErrorSlackView do
 
   defp stripe_account_inactive_message(event) do
     order_id = event["properties"]["data"]["order_id"]
-    merchant_account_external_id = event["properties"]["data"]["merchant_account_external_id"]
-    partner_path = "partners/#{event["properties"]["data"]["partner_id"]}"
+    partner_id = event["properties"]["data"]["partner_id"]
+    partner_path = "partners/#{partner_id}"
+    partner_name = fetch_partner(partner_id)[:name]
+    merchant_account_external_id = fetch_merchant_account(partner_id)[:external_id]
 
     %{
       text: "An order is blocked because the seller's stripe account is inactive.",
@@ -110,7 +112,7 @@ defmodule Apr.Views.CommerceErrorSlackView do
             },
             %{
               title: "Partner",
-              value: "<#{admin_partners_link(partner_path)}|#{event["properties"]["data"]["partner_name"]}>",
+              value: "<#{admin_partners_link(partner_path)}|#{partner_name}>",
               short: true
             },
             %{

--- a/lib/apr/views/helpers/view_helper.ex
+++ b/lib/apr/views/helpers/view_helper.ex
@@ -16,6 +16,22 @@ defmodule Apr.Views.Helper do
     }
   end
 
+  def fetch_partner(partner_id) do
+    partner_response = @gravity_api.get!("/v1/partner/#{partner_id}").body
+
+    %{
+      name: partner_response["name"]
+    }
+  end
+
+  def fetch_merchant_account(partner_id) do
+    merchant_account_response = List.first(@gravity_api.get!("/v1/merchant_accounts?partner_id=#{partner_id}").body)
+
+    %{
+      external_id: merchant_account_response["external_id"]
+    }
+  end
+
   def artwork_link(artwork_id) do
     "https://www.artsy.net/artwork/#{artwork_id}"
   end

--- a/test/apr/views/commerce/commerce_error_slack_view_test.exs
+++ b/test/apr/views/commerce/commerce_error_slack_view_test.exs
@@ -44,8 +44,8 @@ defmodule Apr.Views.CommerceErrorSlackViewTest do
 
     assert Enum.map(List.first(slack_view.attachments).fields, fn field -> field.value end) == [
       "<https://exchange.artsy.net/admin/orders/order1|order1>",
-      "<https://admin-partners.artsy.net/partners/partner1|Partner Name>",
-      "<https://dashboard.stripe.com/connect/accounts/acct_123|acct_123>",
+      "<https://admin-partners.artsy.net/partners/partner1|Mocked Partner2>",
+      "<https://dashboard.stripe.com/connect/accounts/external-id|external-id>",
       "$123.45"
     ]
   end

--- a/test/support/gravity_mock.ex
+++ b/test/support/gravity_mock.ex
@@ -47,6 +47,15 @@ defmodule GravityMock do
     }
   end
 
+  def get!("/v1/merchant_accounts?partner_id=" <> partner_id) do
+    %{
+      body: [%{
+        "id" => partner_id,
+        "external_id" => "external-id"
+      }]
+    }
+  end
+
   def match_partners(_term, _token) do
     %{}
   end


### PR DESCRIPTION
This PR updates the alert for inactive Stripe accounts to fetch the partner name and Stripe account ID instead of expecting it to be present in the event.

We are currently fetching those 2 pieces of information in Exchange when this event originates, but it makes more sense for that data to be fetched by APRd to render this alert. That will allow Exchange to process the failed payment without having to fetch additional data.