### PR TITLE
chore: simplify S3 path for shared configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ $ git clone git@github.com:artsy/aprd.git
   to fix an issue in erlang 23
 - Create and migrate your database with `mix ecto.setup`
 - Install Node.js dependencies with `cd assets && npm install`
-- `s3://artsy-citadel/dev/.env.aprd` contains common configuration values for local dev. Create a `.env.shared` file locally and copy using this command:
+- `s3://artsy-citadel/aprd/.env.shared` contains common configuration values for local dev. Create a `.env.shared` file locally and copy using this command:
 
 ```
-aws s3 cp s3://artsy-citadel/dev/.env.aprd .env.shared
+aws s3 cp s3://artsy-citadel/aprd/.env.shared ./
 ```
 
 - `.env` should contain configuration values specific to your local development. Create the file if it does not exist. See `.env.example` for suggestion on values you might want to customize.

--- a/bin/setup
+++ b/bin/setup
@@ -81,7 +81,7 @@ cd assets && yarn install
 cd ..
 
 echo "Download .env.shared (for common local dev config)..."
-aws s3 cp s3://artsy-citadel/dev/.env.aprd .env.shared
+aws s3 cp s3://artsy-citadel/aprd/.env.shared ./
 
 if [ ! -e ".env" ]; then
   echo "Initialize .env from from .env.example (for any custom configuration)..."
@@ -113,7 +113,7 @@ brew --prefix <service>
 Your local dev environment is setup based on:
 
 - config files in ./config
-- common config in .env.shared (s3://artsy-citadel/dev/.env.aprd)
+- common config in .env.shared (s3://artsy-citadel/aprd/.env.shared)
 
 If those configs do not work for you, you can over-ride in .env.
 If your over-ride should be the default, please update those configs.


### PR DESCRIPTION
As per https://github.com/artsy/README/pull/530, this updates setup to pull shared configuration from its new, simpler location.