### PR TITLE
chore: correct slack links to point to Impulse rather than Radiation

### DIFF
--- a/lib/apr/views/conversation_slack_view.ex
+++ b/lib/apr/views/conversation_slack_view.ex
@@ -47,8 +47,8 @@ defmodule Apr.Views.ConversationSlackView do
                   short: false
                 },
                 %{
-                  title: "Radiation",
-                  value: "#{radiation_conversation_link(event["properties"]["radiation_conversation_id"])}",
+                  title: "Impulse",
+                  value: "#{impulse_email_conversation_link(event["properties"]["radiation_conversation_id"])}",
                   short: false
                 }
               ]

--- a/lib/apr/views/helpers/view_helper.ex
+++ b/lib/apr/views/helpers/view_helper.ex
@@ -50,10 +50,6 @@ defmodule Apr.Views.Helper do
     "<#{artist_link(artist_id)}|#{name}>"
   end
 
-  def radiation_link(path) do
-    "https://radiation.artsy.net/#{path}"
-  end
-
   def impulse_link(path) do
     "https://impulse.artsy.net/#{path}"
   end
@@ -66,9 +62,9 @@ defmodule Apr.Views.Helper do
     "https://www.artsy.net/auction/#{path}"
   end
 
-  def radiation_conversation_link(conversation_id) do
-    conversation_path = "admin/accounts/2/conversations/#{conversation_id}"
-    "<#{radiation_link(conversation_path)}|Conversation(#{conversation_id})>"
+  def impulse_email_conversation_link(email_conversation_id) do
+    email_conversation_path = "active_admin/email_conversations/#{email_conversation_id}"
+    "<#{impulse_link(email_conversation_path)}|EmailConversation(#{email_conversation_id})>"
   end
 
   def impulse_conversation_link(conversation_id) do

--- a/lib/apr/views/radiation_message_slack_view.ex
+++ b/lib/apr/views/radiation_message_slack_view.ex
@@ -3,7 +3,7 @@ defmodule Apr.Views.RadiationMessageSlackView do
 
   def render(_subscription, event) do
     %{
-      text: ":sadbot: #{event["verb"]} event for #{radiation_link(event["object"]["link"])}",
+      text: ":sadbot: #{event["verb"]} event for #{impulse_link(event["object"]["link"])}",
       attachments: [
         %{
           fields: [


### PR DESCRIPTION
Some URL changes are required here, once Impulse takes over Radiation's publishing of conversation events (https://github.com/artsy/impulse/pull/1054#discussion_r1424107360). I can't actually find these messages anywhere in slack, but I'm correcting them for completeness.