### PR TITLE
fix: caseclauseerror on partnererror.created

### DIFF
--- a/lib/apr/views/commerce/commerce_offer_slack_view.ex
+++ b/lib/apr/views/commerce/commerce_offer_slack_view.ex
@@ -11,7 +11,6 @@ defmodule Apr.Views.CommerceOfferSlackView do
     case routing_key do
       "offer.submitted" -> offer_submitted(event)
       "offer.pending_response" -> offer_pending_response(event)
-      "partner_offer.created" -> nil
     end
   end
 

--- a/lib/apr/views/commerce_slack_view.ex
+++ b/lib/apr/views/commerce_slack_view.ex
@@ -16,7 +16,7 @@ defmodule Apr.Views.CommerceSlackView do
       routing_key == "transaction.created" ->
         CommerceTransactionCreatedSlackView.render(subscription, event, routing_key)
 
-      routing_key =~ "offer." ->
+      routing_key =~ ~r/^offer\./ ->
         CommerceOfferSlackView.render(subscription, event, routing_key)
 
       routing_key =~ "order." ->


### PR DESCRIPTION
This PR attempts to stop ~15K errors that are logged to Sentry every week:

- (CaseClauseError) no case clause matching: "partner_offer.created"

This happens because the routing key "partner_offer" is incorrectly matched to the `CommerceOfferSlackView`, which doesn't support it. The solution is to make the pattern matching for that handler only accept routing keys that start with "offer."

cc: @artsy/emerald-devs