### PR TITLE
feat: migrate ingress to new controllers (production)

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -109,11 +109,11 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: aprd
+  name: aprd-2025
   annotations:
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ externalIngressAllowSourceIP|join(',') }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: external-nginx
   rules:
   - host: aprd.artsy.net
     http:


### PR DESCRIPTION
This PR resolves [PHIRE-2267]

### Description

The existing Ingress Controllers are not scalable. We have [created a new set](https://github.com/artsy/substance/pull/446) that are scalable.

This PR migrates ingresses to the new controllers.

Migration:
---
- [ ] Merge this PR.
- [ ] Merge subsequent Deploy PR.
- [ ] Wait for Prod deployment to finish.
- [ ] Point the app's external DNS (if any) to the new controllers (`nginx-2025.artsy.net`). This should be done via Infrastructure repo if the record is managed there.
- [x] Point the app's internal DNS (if any) to the new controllers (`nginx-2025.prd.artsy.systems`). This should be done via Substance repo if the record is managed there.
- [ ] Verify that the app still works.
- [ ] Wait 1 day.
- [ ] Delete old ingress via kubectl. (`kubectl --context production delete ingress <old-ingress-name>`)

[PHIRE-2267]: https://artsyproduct.atlassian.net/browse/PHIRE-2267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ